### PR TITLE
typo

### DIFF
--- a/_includes/README.html
+++ b/_includes/README.html
@@ -1,4 +1,3 @@
-
 <p>
 Sinatra is a DSL for quickly creating web applications in Ruby with minimal
 effort:
@@ -538,7 +537,7 @@ routes, error handlers) through the `request` method:
     request.path              # &quot;/example/foo&quot;
     request.ip                # client IP address
     request.secure?           # false
-    requuest.env              # raw env hash handed in by Rack
+    request.env              # raw env hash handed in by Rack
   end
 </pre>
 <p>


### PR DESCRIPTION
Fixed typo on the README.html (aka intro) page.
