### PR TITLE
Fixed a trivial typo in the environment name

### DIFF
--- a/_includes/README.html
+++ b/_includes/README.html
@@ -1693,7 +1693,7 @@ environment variable, and default value is <tt>development</tt>.</p>
 <p>You can use predefinied methods: <tt>development?</tt>, <tt>test?</tt> and
 <tt>production?</tt>, to check which enviroment is set.</p>
 
-<p><tt>Developemnt</tt> is default setting. In this mode, all templates are
+<p><tt>Development</tt> is default setting. In this mode, all templates are
 being reloaded between requests. Special <tt>not_found</tt> and
 <tt>error</tt> handlers are installed for this enviroment, so you will see
 nice error page. In <tt>production</tt> and <tt>test</tt> templates are


### PR DESCRIPTION
This commit corrects 'Developemnt' to the correct 'Development' environment name.
