### PR TITLE
Explain that Sinatra::Contrib is an external gem

### DIFF
--- a/contrib/index.markdown
+++ b/contrib/index.markdown
@@ -19,6 +19,14 @@ Sinatra::Contrib.  *Custom extensions*, on the other hand, may add additional
 dependencies and enhance the behavior of the existing APIs.
 
 
+## Installation
+
+All Sinatra::Contrib extensions are bundled in the `sinatra-contrib` gem.
+
+    gem install sinatra-contrib
+
+
+
 ## Usage
 
 ### In Classic Style Applications


### PR DESCRIPTION
The Sinatra::Contrib front page should clearly indicate that all extensions are bundled in the `sinatra-contrib` gem.
