### PR TITLE
No longer implicitly encourage disabling CSRF protection

### DIFF
--- a/_includes/README.html
+++ b/_includes/README.html
@@ -1558,7 +1558,7 @@ end</pre>
 <p>Sinatra is using <a
 href="https://github.com/rkh/rack-protection#readme">Rack::Protection</a>
 to defend you application against common, opportunistic attacks. You can
-easily disable this behavior (which should result in performance gains):</p>
+disable this behavior if needed:</p>
 
 <pre>disable :protection</pre>
 


### PR DESCRIPTION
As @wycats noted at Railsberry, the text about protection implicitly encourages people to disable CSRF protection by promising a performance boost -- probably not the right way to present the topic :)
