### PR TITLE
Fix error at escape html FAQ block

### DIFF
--- a/faq.markdown
+++ b/faq.markdown
@@ -235,7 +235,7 @@ in your helpers and create an `h` alias as follows:
 
     helpers do
       include Rack::Utils
-      alias_method :escape, :h
+      alias_method :h, :escape
     end
 
 Now you can escape html in your templates like this:


### PR DESCRIPTION
Hi all! There is a mistake at official website.
http://www.sinatrarb.com/faq.html#escape_html
We should swap params creating alias method h
