### PR TITLE
Remove `-rubygems` from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@ end</code></pre>
 
 <div class='pipe shell'>
 <pre><code>$ gem install sinatra
-$ ruby -rubygems hi.rb
+$ ruby hi.rb
 == Sinatra has taken the stage ...
 >> Listening on 0.0.0.0:4567
 </code></pre>


### PR DESCRIPTION
It's 2012. Everyone uses 1.9
