### PR TITLE
Fix method name at escape html FAQ block

### DIFF
--- a/faq.markdown
+++ b/faq.markdown
@@ -235,7 +235,7 @@ in your helpers and create an `h` alias as follows:
 
     helpers do
       include Rack::Utils
-      alias_method :h, :escape
+      alias_method :h, :escape_html
     end
 
 Now you can escape html in your templates like this:


### PR DESCRIPTION
Rack::Utils#escape exists, but it is the method for URI escape.
The method for HTML escape is Rack::Utils#escape_html.
In refered page escape_html is also used,
please see http://www.gittr.com/index.php/archive/using-rackutils-in-sinatra-escape_html-h-in-rails/
