### PR TITLE
Another one for testing: Capybara::DSL instead of Capybara

### DIFF
--- a/testing.markdown
+++ b/testing.markdown
@@ -315,7 +315,7 @@ From `Webrat`'s wiki where you'll find more [examples][].
     require 'test/unit'
 
     class HelloWorldTest < Test::Unit::TestCase
-      include Capybara
+      include Capybara::DSL
       # Capybara.default_driver = :selenium # <-- use Selenium driver
 
       def setup


### PR DESCRIPTION
include Capybara was deprecated in favour of Capybara::DSL as we can see in:
`include Capybara` is deprecated please use `include Capybara::DSL` instead.
