### PR TITLE
Corrected FAQ answer regarding escaping HTML

### DIFF
--- a/faq.markdown
+++ b/faq.markdown
@@ -235,7 +235,7 @@ in your helpers and create an `h` alias as follows:
 
     helpers do
       include Rack::Utils
-      alias_method :h, :escape
+      alias_method :h, :escape_html
     end
 
 Now you can escape html in your templates like this:


### PR DESCRIPTION
Hello,

I found a small documentation bug in the Sinatra FAQ.  The question "How do I escape html?" has a good answer, but the escape method does URL encoding, whereas escape_html is what's being called for here.
