### PR TITLE
Change typeface and colors

### DIFF
--- a/css/legend.css
+++ b/css/legend.css
@@ -1,9 +1,9 @@
 body {
-  color:#000;
-  font-family:helvetica, sans-serif;
+  color:#222;
+  font-family: 'Lucida Grande', 'Lucida Sans', Tahoma, Ubuntu sans-serif;
   font-size:100%;
   line-height:1.25;
-  background-color:#fff;
+  background-color:#FAFAFA;
   margin:0;
   padding:0;
 }


### PR DESCRIPTION
Helvetica is amazing but not for web, not for reading on web. 

Check out the difference:  http://screencast.com/t/TraYxbmiIc

( http://www.wired.com/magazine/2011/05/ff_ycombinator/all/1 )

On left is **Lucida Grande** and on right is **Helvetica**.

Changing font stack to:
- **Lucida Grande** - available on all Macs and some versions of Windwos.
- **Lucida Sans** - available on most Windows
- **Tahoma** - available on all Windows
- **Ubuntu** - available on Ubuntu - popular distro of Linux
- **sans-serif** - for rest of the immortal world.

Also:

Pure black words (#000) on pure white (#FFF) are hard on eyes. 

Making it a bit subtle with:
# FAFAFA and #222
