### PR TITLE
Proper capitals in HTML, PDF and GitHub; Drop email to all lowercase

### DIFF
--- a/contributing.markdown
+++ b/contributing.markdown
@@ -45,7 +45,7 @@ can be applied as quickly as possible:
 4. **Push it:** Once you're ready, push your changes to a topic branch
    and add a note to the ticket with the URL to your branch. Or, say
    something like, "you can find the patch on johndoe/foobranch". We also
-   gladly accept Github [pull requests](http://help.github.com/pull-requests/).
+   gladly accept GitHub [pull requests](http://help.github.com/pull-requests/).
 
 __NOTE:__ _we will take whatever we can get._ If you prefer to
 attach diffs in emails to the mailing list, that's fine; but do know

--- a/extensions-wild.markdown
+++ b/extensions-wild.markdown
@@ -30,9 +30,9 @@ and requiring a file. Consult these steps if you run into problems:
 These extensions add helper methods to the request context:
 
 1. [sinatra-prawn](http://github.com/sbfaulkner/sinatra-prawn/)
-   adds support for pdf rendering with Prawn templates.
+   adds support for PDF rendering with Prawn templates.
 1. [sinatra-markaby](http://github.com/sbfaulkner/sinatra-markaby/)
-   enables rendering of html files using markaby templates.
+   enables rendering of HTML files using markaby templates.
 1. [sinatra-maruku](http://github.com/wbzyl/sinatra-maruku/)
    provides Maruku templates for a Sinatra application.
 1. [sinatra-rdiscount](http://github.com/wbzyl/sinatra-rdiscount/)

--- a/faq.markdown
+++ b/faq.markdown
@@ -197,7 +197,7 @@ Try starting Thin with the `--debug` argument:
 
 That should give you an exception and backtrace on `stderr`.
 
-How do I send Email from Sinatra? {#email}
+How do I send email from Sinatra? {#email}
 ---------------------------------
 
 How about a [Pony](http://adam.heroku.com/past/2008/11/2/pony_the_express_way_to_send_email_from_ruby/)
@@ -227,7 +227,7 @@ And in `mailerapp.rb`:
                 :body => erb(:email)
     end
 
-How do I escape html? {#escape_html}
+How do I escape HTML? {#escape_html}
 ---------------------
 
 Include [Rack::Utils](http://rack.rubyforge.org/doc/classes/Rack/Utils.html)
@@ -238,14 +238,14 @@ in your helpers and create an `h` alias as follows:
       alias_method :h, :escape_html
     end
 
-Now you can escape html in your templates like this:
+Now you can escape HTML in your templates like this:
 
     <%= h scary_output %>
 
 Thanks to [Chris Schneider](http://www.gittr.com/index.php/archive/using-rackutils-in-sinatra-escape_html-h-in-rails/)
 for the tip!
 
-How do I automatically escape html? {#auto_escape_html}
+How do I automatically escape HTML? {#auto_escape_html}
 ---------------------
 
 Require [Erubis](http://rubygems.org/gems/erubis) and set `escape_html` to `true`:

--- a/wild.markdown
+++ b/wild.markdown
@@ -74,7 +74,7 @@ Applications {#apps}
 - [Hancock Client](http://github.com/atmos/hancock-client/tree/master) Rack
   middleware client for the Hancock server, written in Sinatra
 - [Rails Searchable API Doc](http://railsapi.com/) runs on Sinatra
-- [Sinatra Saucer](http://github.com/angelic/sinatra_saucer) JRuby web application frontend for Flying Saucer, which converts xhtml into a pdf
+- [Sinatra Saucer](http://github.com/angelic/sinatra_saucer) JRuby web application frontend for Flying Saucer, which converts XHTML into a PDF
 - [Wink](http://github.com/rtomayko/wink) minimalist blogging engine
 - [WineAdds](http://wineadds.com) micro-app that calculates common additions to wine
 - [Deltacloud](http://www.deltacloud.org) Deltacloud protects your apps from cloud API changes and incompatibilies. REST API is written using Sinatra
@@ -82,7 +82,7 @@ Applications {#apps}
 - [Jaconda](http://jaconda.im) A simple team collaboration service that allows you to create chat rooms for groups through Gtalk/Jabber protocol. REST API is written in Sinatra
 - [Soxer](http://soxer.mutsu.org/) Soxer is a lean but infinitely extensible web publishing tool.
 - [SinMagick](http://blog.50projects.com/p/sinmagick-image-processing.html) a front-end for image processing and thumbnailing with flexible storage options.
-- [Brakes](http://github.com/rdnck76/brakes) a simple sinatra app for hosting static html on heroku.
+- [Brakes](http://github.com/rdnck76/brakes) a simple sinatra app for hosting static HTML on heroku.
 - [Fundry - Crowdfunding for Software Development](http://fundry.com) - Fundry is designed around software projects, helping developers get paid for developing new features, and enabling your community to pledge to get the features they want. The site and API (coming soon) is all written in Sinatra.
 - [Picky](http://github.com/floere/picky) - a fast &amp; clever semantic search engine.
 - [Headhunter](http://headhunter.heroku.com) - giving Twitter profile pics a permanent URL


### PR DESCRIPTION
Minor case issues on when those terms used in sentences, outside of URLs.
