### PR TITLE
Fixed Typo for sinatra-cookies to be consistent cookies

### DIFF
--- a/_includes/sinatra-cookies.html
+++ b/_includes/sinatra-cookies.html
@@ -8,7 +8,7 @@
 <p>Allows you to read cookies:</p>
 
 <pre>get '/' do
-  &quot;value: #{cookie[:something]}&quot;
+  &quot;value: #{cookies[:something]}&quot;
 end</pre>
 
 <p>And of course to write cookies:</p>


### PR DESCRIPTION
Typo was that cookie should be cookies.
