### PR TITLE
Comma and the where they should not be in blog posts; And hissing

### DIFF
--- a/_posts/2009-01-29-we-have-a-faq-now.markdown
+++ b/_posts/2009-01-29-we-have-a-faq-now.markdown
@@ -12,5 +12,5 @@ logs and mailing list threads to compile the initial set of entries and
 we'll be adding to the list considerably over the coming weeks.
 
 Have an idea for a FAQ entry? Fork the
-[sinatra.github.com repository](http://github.com/sinatra/sinatra.github.com/),
+[sinatra.github.com repository](https://github.com/sinatra/sinatra.github.com),
 add the entry to `faq.markdown`, and push. We'll take care of the rest.

--- a/_posts/2011-03-03-blog-revived.markdown
+++ b/_posts/2011-03-03-blog-revived.markdown
@@ -7,6 +7,6 @@ publish_date: Thursday, March 3, 2011
 ---
 
 It has been quiet on this blog recently. Announcements, like the 1.0 and 1.1
-releases have only been made on the mailing list. Plans are to change this and
+releases, have only been made on the mailing list. Plans are to change this and
 accompany mailing list announcements with in-depth articles about new feature
 releases.

--- a/_posts/2011-03-03-sinatra-1.2.0.markdown
+++ b/_posts/2011-03-03-sinatra-1.2.0.markdown
@@ -104,7 +104,7 @@ end
 
 Usually Sinatra does not provide any view helper methods. Those are provided by
 extensions and would not suit Sinatra's approach of a small but robust core.
-However, constructing URLs is a use case most people run in sooner or later.
+However, constructing URLs is a use case most people run into sooner or later.
 It is a bit complicated to construct URLs right. Consider this example:
 
 {% highlight ruby %}
@@ -182,7 +182,7 @@ available.
 ## Configurable redirects
 
 In 1.1 we made sure all redirects were absolute URIs, to conform with RFC 2616
-(HTTP 1.1). This will result in issues for you, if you have a broken Reverse
+(HTTP 1.1). This will result in issues for you if you have a broken Reverse
 Proxy configuration. If so, you should really fix your configuration. If you are
 unable to do so, a simple `disable :absolute_redirects` will now give you back
 the 1.0 behavior. As shown above, you can now use the `to` helper with redirect.

--- a/_posts/2011-09-30-sinatra-1.3.0.markdown
+++ b/_posts/2011-09-30-sinatra-1.3.0.markdown
@@ -114,7 +114,7 @@ Sinatra-Contrib
 There are a lot of Sinatra extensions out there, and some of those are used by a
 large number of apps, like sinatra-content-for or sinatra-reloader. The
 maintainers of these extensions have to keep up with new Sinatra releases to
-make sure everything works fine. This poses an issue from time to time, esp.
+make sure everything works fine. This poses an issue from time to time, especially
 since some of these extensions were relying on Sinatra internals. To fix this,
 we created the sinatra-contrib project (source code at
 https://github.com/sinatra/sinatra-contrib). This project contains a number of
@@ -130,10 +130,10 @@ extensions shipping with sinatra-contrib will be made available on the Sinatra
 website. I would not have managed to take care of this all by my self, so I'm
 really grateful that Gabriel Andretta jumped in to help with this project.
 
-Documentation is available at http://www.sinatrarb.com/contrib.
+Documentation is available at [sinatrarb.com/contrib](http://www.sinatrarb.com/contrib).
 
 Sinatra Recipes
 ---------------
 
-Zachary Scott recently launched the the [Recipes](http://recipes.sinatrarb.com/)
+Zachary Scott recently launched the [Recipes](http://recipes.sinatrarb.com/)
 project. It contains community contributed recipes and techniques for Sinatra.


### PR DESCRIPTION
- Extra "the" on "New feature release, Contrib and Recipes"
- Moved around a couple of commas to help with the sentence flow
- Updated GitHub links to HTTPS while at it
- Thought an active link would be quicker on the draw
  than a bare text URL
