### PR TITLE
Fix for typo in 'Configuring attack protection' section

### DIFF
--- a/_includes/README.html
+++ b/_includes/README.html
@@ -1557,7 +1557,7 @@ end</pre>
 
 <p>Sinatra is using <a
 href="https://github.com/rkh/rack-protection#readme">Rack::Protection</a>
-to defend you application against common, opportunistic attacks. You can
+to defend your application against common, opportunistic attacks. You can
 easily disable this behavior (which will open your application to tons of
 common vulnerabilities):</p>
 


### PR DESCRIPTION
Should be 'your' instead of 'you' shouldn't it?
