### PR TITLE
Update bind docs in configuration.markdown

### DIFF
--- a/configuration.markdown
+++ b/configuration.markdown
@@ -190,11 +190,19 @@ first available handler. The `:server` setting is set as follows by default:
 ### `:bind` - server hostname or IP address
 
 String specifying the hostname or IP address of the interface to listen on
-when the `:run` setting is enabled. The default value -- `'0.0.0.0'` -- causes
-the server to listen on all available interfaces. To listen on the
-loopback interface only, use:
+when the `:run` setting is enabled. The default value in the development
+environment is `'localhost'` which means the server is only available from the
+local machine. In other environments the default is `'0.0.0.0'`, which causes
+the server to listen on all available interfaces.
 
-    set :bind, 'localhost'
+To listen on all interfaces in the development environment (for example if you
+want to test from other computers in your local network) use:
+
+    set :bind, '0.0.0.0'
+
+This can also be set from the command line with the `-o` option. If you set the
+bind option in your application it will override anything set on the command
+line.
 
 ### `:port` - server port
 


### PR DESCRIPTION
The default value for `:bind` has changed in development (see
sinatra/sinatra@0f9a959253bdf0c39422ffb9b60278df46ef0248).

Update configuration docs to account for new defaults.
