### PR TITLE
Escape [] to avoid Maruku warnings

### DIFF
--- a/wild.markdown
+++ b/wild.markdown
@@ -78,7 +78,7 @@ Applications {#apps}
 - [Git-Webby](https://github.com/codigorama/git-webby) - Git Smart HTTP Ruby/Sinatra implementation with useful features.
 - [Trudy](https://github.com/quimarche/trudy) - A Nabaztag server.
 - [Markdown Tree](https://github.com/mil/markdown-tree) - Serve a Hierarchy of Markdown files simply (like mksite or other site generators, only dynamic)
-- [Fracture.it](http://fracture.it) URL shortening service [[Source](https://github.com/michaelminter/fracture-url)]
+- [Fracture.it](http://fracture.it) URL shortening service \[[Source](https://github.com/michaelminter/fracture-url)\]
 - [streetart.io](http://itunes.com/app/streetartio) streetart.io allows you to share and discover interesting street art, public art and sculptures around you and your city. API is powered by Sinatra and Redis.
 - [TaskwarriorWeb](http://theunraveler.github.com/taskwarrior-web/) - A Sinatra-based web interface for the Taskwarrior todo application. Because being a neck-beard is only fun sometimes.
 - [Travis CI](https://travis-ci.org/) - Free Hosted Continuous Integration Platform for the Open Source Community


### PR DESCRIPTION
Generating the site was producing warnings:

```
 ___________________________________________________________________________
| Maruku tells you:
+---------------------------------------------------------------------------
| Could not find ref_id = "md_im_linksource_httpsgithubcommichaelminterfractureurl_nil" for md_link([
|       md_im_link(["Source"], "https://github.com/michaelminter/fracture-url", nil)
| ],"md_im_linksource_httpsgithubcommichaelminterfractureurl_nil")
| Available refs are []
+---------------------------------------------------------------------------
!/Users/matt/.rvm/gems/ruby-1.9.3-p385/gems/maruku-0.6.1/lib/maruku/errors_management.rb:49:in `maruku_error'
!/Users/matt/.rvm/gems/ruby-1.9.3-p385/gems/maruku-0.6.1/lib/maruku/output/to_html.rb:716:in `to_html_link'
!/Users/matt/.rvm/gems/ruby-1.9.3-p385/gems/maruku-0.6.1/lib/maruku/output/to_html.rb:970:in `block in array_to_html'
!/Users/matt/.rvm/gems/ruby-1.9.3-p385/gems/maruku-0.6.1/lib/maruku/output/to_html.rb:961:in `each'
!/Users/matt/.rvm/gems/ruby-1.9.3-p385/gems/maruku-0.6.1/lib/maruku/output/to_html.rb:961:in `array_to_html'
\___________________________________________________________________________
Not creating a link for ref_id = "md_im_linksource_httpsgithubcommichaelminterfractureurl_nil".
```

Escaping the `[]` chars removed these warnings (and makes the brackets appear in the html, which I think was the intent.)
