### PR TITLE
update FAQ partials answer to point to sinatra-recipes project

### DIFF
--- a/faq.markdown
+++ b/faq.markdown
@@ -132,33 +132,10 @@ follows:
 
     <%= erb :mypartial, :layout => false %>
 
-See [Sam Elliott](http://www.lenary.co.uk/) and [Iain Barnett](http://iainbarnett.me.uk/)'s
-[Sinatra-Partial extension](https://github.com/yb66/Sinatra-Partial)
-for a more robust partials implementation. It also supports rendering
-collections and partials in subdirectories.
-
-The code used to live in a [gist](https://gist.github.com/119874),
-but we have put it in a gem so we can maintain it properly and
-provide an easier way for developers to include its behaviour.
-It was adapted from [Chris Schneider](http://www.gittr.com/)'s
-original [partials.rb](https://github.com/cschneid/irclogger/blob/master/lib/partials.rb)
-implementation.
-
-Use it as follows to render the `mypartial.haml`(1) or the `admin/mypartial.haml`(2)
-partials, or with a collection (3) & (4):
-
-    <%= partial(:mypartial) %> <!--(1)-->
-    <%= partial(:'admin/mypartial') %> <!--(2)-->
-    <%= partial(:object, :collection => @objects) %> <!--(3)-->
-    <%= partial(:'admin/object', :collection => @objects) %> <!--(4)-->
-
-In (1) & (2), the partial will be rendered plain from their files, with no
-local variables (specify them with a hash passed into `:locals`).
-In (3) & (4), the partials will be rendered, populating the local
-variable `object` with each of the objects from the collection.
-
-It is also possible to enable using underscores, a la Rails, and
-to choose a different rendering engine from haml.
+If you are interested in more robust partials solutions, check out the 
+[sinatra-recipes project](http://recipes.sinatrarb.com/), which has articles on
+using the [sinatra-partial gem](http://recipes.sinatrarb.com/p/helpers/partials_using_the_sinatra-partial_gem?#article) or 
+[implementing your own Rails-style patrials](http://recipes.sinatrarb.com/p/helpers/partials?#article).
 
 
 Can I have multiple URLs trigger the same route/handler? {#multiroute}


### PR DESCRIPTION
there are 2 entries in sinatra-recipes about partials, i think the FAQ should point to them instead of documenting some of that content on its own. it will be easier to keep comprehensive and up to date if the content is in a single place.

i have a WIP article that i'm finishing up on Rails-style partials, available for review here: https://github.com/sinatra/sinatra-recipes/pull/69