### PR TITLE
Add in info about inheriting from Sinatra::Application

### DIFF
--- a/_includes/README.html
+++ b/_includes/README.html
@@ -2803,7 +2803,8 @@ of <code>Sinatra::Base</code>.</li>
 <p><code>Sinatra::Base</code> is a blank slate. Most options are disabled by default,
 including the built-in server. See
 <a href="http://sinatra.github.com/configuration.html">Options and Configuration</a>
-for details on available options and their behavior.</p>
+for details on available options and their behavior. Inheriting from <code>Sinatra::Application</code>
+allows modular applications to have the same settings enabled as in a classic application.</p>
 
 <a name='Modular%20vs.%20Classic%20Style'></a>
 <h3>Modular vs. Classic Style</h3>
@@ -2828,7 +2829,7 @@ different default settings:</p>
 <tr>
 <td>app_file</td>
     <td>file loading sinatra</td>
-    <td>file subclassing Sinatra::Base</td>
+    <td>file subclassing Sinatra::Base or Sinatra::Application</td>
   </tr>
 <tr>
 <td>run</td>


### PR DESCRIPTION
I am currently teaching 26 people how to program in gSchool. We ran into an issue inheriting from Sinatra::Base where the HTTP method overriding using a hidden form field didn't work when inheriting from Sinatra::Base while it worked for a classic application

This commit adds in a note that you can inherit from Sinatra::Application to get the same settings as a classic application to make it a little more clear.
