### PR TITLE
Change 'jp' code to 'ja'

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ end
 
 def readme(pattern = "%s", &block)
   return readme(pattern).each(&block) if block_given?
-  %w[en de es fr hu jp zh ru ko pt-br pt-pt].map do |lang|
+  %w[en de es fr hu ja zh ru ko pt-br pt-pt].map do |lang|
     pattern % "README#{lang == "en" ? "" : ".#{lang}"}"
   end
 end


### PR DESCRIPTION
Update `Rakefile` to use `ja` rather than `jp` to match renamed Japanese readme (see sinatra/sinatra@ab37432c6a8f3676e8027d76606b370ad2b86662). This was causing an error `No such file or directory @ rb_sysopen - _sinatra/README.jp.md` when trying to build the site.

---

Change language code for Japanese readme to 'ja'.
See sinatra/sinatra@ab37432c6a8f3676e8027d76606b370ad2b86662
