### PR TITLE
Rebuild with a corrected README.ja.md

### DIFF
--- a/_includes/README.ja.html
+++ b/_includes/README.ja.html
@@ -66,7 +66,41 @@
 		<ol class='level-2'>
 			<li><a href='#%E6%94%BB%E6%92%83%E9%98%B2%E5%BE%A1%E3%81%AB%E5%AF%BE%E3%81%99%E3%82%8B%E8%A8%AD%E5%AE%9A'>攻撃防御に対する設定</a></li>
 			<li><a href='#%E5%88%A9%E7%94%A8%E5%8F%AF%E8%83%BD%E3%81%AA%E8%A8%AD%E5%AE%9A'>利用可能な設定</a></li>
-	</ol></ol>
+		</ol>
+		<li><a href='#%E7%92%B0%E5%A2%83%E8%A8%AD%E5%AE%9A(Environments)'>環境設定(Environments)</a></li>
+		<li><a href='#%E3%82%A8%E3%83%A9%E3%83%BC%E3%83%8F%E3%83%B3%E3%83%89%E3%83%AA%E3%83%B3%E3%82%B0(Error%20Handling)'>エラーハンドリング(Error Handling)</a></li>
+		<ol class='level-2'>
+			<li><a href='#%E6%9C%AA%E6%A4%9C%E5%87%BA(Not%20Found)'>未検出(Not Found)</a></li>
+			<li><a href='#%E3%82%A8%E3%83%A9%E3%83%BC(Error)'>エラー(Error)</a></li>
+		</ol>
+		<li><a href='#Rack%E3%83%9F%E3%83%89%E3%83%AB%E3%82%A6%E3%82%A7%E3%82%A2(Rack%20Middleware)'>Rackミドルウェア(Rack Middleware)</a></li>
+		<li><a href='#%E3%83%86%E3%82%B9%E3%83%88(Testing)'>テスト(Testing)</a></li>
+		<li><a href='#Sinatra::Base%20-%20%E3%83%9F%E3%83%89%E3%83%AB%E3%82%A6%E3%82%A7%E3%82%A2%E3%80%81%E3%83%A9%E3%82%A4%E3%83%96%E3%83%A9%E3%83%AA%E3%81%8A%E3%82%88%E3%81%B3%E3%83%A2%E3%82%B8%E3%83%A5%E3%83%A9%E3%83%BC%E3%82%A2%E3%83%97%E3%83%AA'>Sinatra::Base - ミドルウェア、ライブラリおよびモジュラーアプリ</a></li>
+		<ol class='level-2'>
+			<li><a href='#%E3%83%A2%E3%82%B8%E3%83%A5%E3%83%A9%E3%83%BC%E3%82%B9%E3%82%BF%E3%82%A4%E3%83%AB%20vs%20%E3%82%AF%E3%83%A9%E3%83%83%E3%82%B7%E3%83%83%E3%82%AF%E3%82%B9%E3%82%BF%E3%82%A4%E3%83%AB'>モジュラースタイル vs クラッシックスタイル</a></li>
+			<li><a href='#%E3%83%A2%E3%82%B8%E3%83%A5%E3%83%A9%E3%83%BC%E3%82%A2%E3%83%97%E3%83%AA%E3%82%B1%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%81%AE%E6%8F%90%E4%BE%9B'>モジュラーアプリケーションの提供</a></li>
+			<li><a href='#config.ru%E3%82%92%E7%94%A8%E3%81%84%E3%81%9F%E3%82%AF%E3%83%A9%E3%83%83%E3%82%B7%E3%83%83%E3%82%AF%E3%82%B9%E3%82%BF%E3%82%A4%E3%83%AB%E3%82%A2%E3%83%97%E3%83%AA%E3%82%B1%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%81%AE%E4%BD%BF%E7%94%A8'>config.ruを用いたクラッシックスタイルアプリケーションの使用</a></li>
+			<li><a href='#config.ru%E3%81%AF%E3%81%84%E3%81%A4%E4%BD%BF%E3%81%86%E3%81%AE%E3%81%8B%EF%BC%9F'>config.ruはいつ使うのか？</a></li>
+			<li><a href='#Sinatra%E3%81%AE%E3%83%9F%E3%83%89%E3%83%AB%E3%82%A6%E3%82%A7%E3%82%A2%E3%81%A8%E3%81%97%E3%81%A6%E3%81%AE%E5%88%A9%E7%94%A8'>Sinatraのミドルウェアとしての利用</a></li>
+			<li><a href='#%E5%8B%95%E7%9A%84%E3%81%AA%E3%82%A2%E3%83%97%E3%83%AA%E3%82%B1%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%81%AE%E7%94%9F%E6%88%90'>動的なアプリケーションの生成</a></li>
+		</ol>
+		<li><a href='#%E3%82%B9%E3%82%B3%E3%83%BC%E3%83%97%E3%81%A8%E3%83%90%E3%82%A4%E3%83%B3%E3%83%87%E3%82%A3%E3%83%B3%E3%82%B0(Scopes%20and%20Binding)'>スコープとバインディング(Scopes and Binding)</a></li>
+		<ol class='level-2'>
+			<li><a href='#%E3%82%A2%E3%83%97%E3%83%AA%E3%82%B1%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3/%E3%82%AF%E3%83%A9%E3%82%B9%E3%81%AE%E3%82%B9%E3%82%B3%E3%83%BC%E3%83%97'>アプリケーション/クラスのスコープ</a></li>
+			<li><a href='#%E3%83%AA%E3%82%AF%E3%82%A8%E3%82%B9%E3%83%88/%E3%82%A4%E3%83%B3%E3%82%B9%E3%82%BF%E3%83%B3%E3%82%B9%E3%81%AE%E3%82%B9%E3%82%B3%E3%83%BC%E3%83%97'>リクエスト/インスタンスのスコープ</a></li>
+			<li><a href='#%E3%83%87%E3%83%AA%E3%82%B2%E3%83%BC%E3%83%88%E3%82%B9%E3%82%B3%E3%83%BC%E3%83%97'>デリゲートスコープ</a></li>
+		</ol>
+		<li><a href='#%E3%82%B3%E3%83%9E%E3%83%B3%E3%83%89%E3%83%A9%E3%82%A4%E3%83%B3'>コマンドライン</a></li>
+		<li><a href='#%E5%BF%85%E8%A6%81%E7%92%B0%E5%A2%83'>必要環境</a></li>
+		<li><a href='#%E6%9C%80%E6%96%B0%E9%96%8B%E7%99%BA%E7%89%88'>最新開発版</a></li>
+		<ol class='level-2'>
+			<li><a href='#Bundler%E3%82%92%E4%BD%BF%E3%81%86%E5%A0%B4%E5%90%88'>Bundlerを使う場合</a></li>
+			<li><a href='#%E7%9B%B4%E6%8E%A5%E7%B5%84%E3%81%BF%E8%BE%BC%E3%82%80%E5%A0%B4%E5%90%88'>直接組み込む場合</a></li>
+			<li><a href='#%E3%82%B0%E3%83%AD%E3%83%BC%E3%83%90%E3%83%AB%E7%92%B0%E5%A2%83%E3%81%AB%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB%E3%81%99%E3%82%8B%E5%A0%B4%E5%90%88'>グローバル環境にインストールする場合</a></li>
+		</ol>
+		<li><a href='#%E3%83%90%E3%83%BC%E3%82%B8%E3%83%A7%E3%83%8B%E3%83%B3%E3%82%B0(Versioning)'>バージョニング(Versioning)</a></li>
+		<li><a href='#%E5%8F%82%E8%80%83%E6%96%87%E7%8C%AE'>参考文献</a></li>
+	</ol>
 </div>
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
 <html><body>
@@ -1967,7 +2001,7 @@ get <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710
   <dt>type</dt>
     <dd>コンテンツの種類。設定がない場合、ファイル拡張子から類推される。</dd>
 
-  disposition
+  <dt>disposition</dt>
     <dd>
       Content-Dispositionに使われる。許容値: <tt>nil</tt> (デフォルト)、
       <tt>:attachment</tt> および <tt>:inline</tt>
@@ -2295,10 +2329,9 @@ set <span style="color:#A60">:protection</span>, <span style="color:#A60">:sessi
   </dd>
 
   <dt>bind</dt>
-  <dd>バインドするIPアドレス(デフォルト: `environment`がdevelopmentにセットされているときは、<tt>0.0.0.0</tt> <em>または</em> <tt>localhost</tt>)。ビルトインサーバでのみ使われる。
+  <dd>バインドするIPアドレス(デフォルト: `environment`がdevelopmentにセットされているときは、<tt>0.0.0.0</tt> <em>または</em> <tt>localhost</tt>)。ビルトインサーバでのみ使われる。</dd>
 
-  </dd>
-<dt>default_encoding</dt>
+  <dt>default_encoding</dt>
   <dd>不明なときに仮定されるエンコーディング(デフォルトは<tt>"utf-8"</tt>)。</dd>
 
   <dt>dump_errors</dt>
@@ -2415,212 +2448,258 @@ set <span style="color:#A60">:protection</span>, <span style="color:#A60">:sessi
   <dd>
     マッチするルーティングが無い場合に、X-Cascadeヘッダをセットするか否かの設定。デフォルトは<tt>true</tt>。
   </dd>
+</dl>
+<a name='%E7%92%B0%E5%A2%83%E8%A8%AD%E5%AE%9A(Environments)'></a>
+<h2>環境設定(Environments)</h2>
 
+<p>３種類の既定環境、<code>"development"</code>、<code>"production"</code>および<code>"test"</code>があります。環境は、<code>RACK_ENV</code>環境変数を通して設定できます。デフォルト値は、<code>"development"</code>です。<code>"development"</code>環境において、すべてのテンプレートは、各リクエスト間で再ロードされ、そして、特別の<code>not_found</code>および<code>error</code>ハンドラがブラウザにスタックトレースを表示します。<code>"production"</code>および<code>"test"</code>環境においては、テンプレートはデフォルトでキャッシュされます。</p>
 
-## 環境設定(Environments)
+<p>異なる環境を走らせるには、<code>RACK_ENV</code>環境変数を設定します。</p>
 
-３種類の既定環境、`"development"`、`"production"`および`"test"`があります。環境は、`RACK_ENV`環境変数を通して設定できます。デフォルト値は、`"development"`です。`"development"`環境において、すべてのテンプレートは、各リクエスト間で再ロードされ、そして、特別の`not_found`および`error`ハンドラがブラウザにスタックトレースを表示します。`"production"`および`"test"`環境においては、テンプレートはデフォルトでキャッシュされます。
+<div>
+<div class="CodeRay">
+  <div class="code"><pre>RACK_ENV=production ruby my_app.rb
+</pre></div>
+</div>
+</div>
 
-異なる環境を走らせるには、`RACK_ENV`環境変数を設定します。
+<p>既定メソッド、<code>development?</code>、<code>test?</code>および<code>production?</code>を、現在の環境設定を確認するために使えます。</p>
 
-~~~~shell
-RACK_ENV=production ruby my_app.rb
-~~~~
+<div>
+<div class="CodeRay">
+  <div class="code"><pre>get <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">/</span><span style="color:#710">'</span></span> <span style="color:#080;font-weight:bold">do</span>
+  <span style="color:#080;font-weight:bold">if</span> settings.development?
+    <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">"</span><span style="color:#D20">development!</span><span style="color:#710">"</span></span>
+  <span style="color:#080;font-weight:bold">else</span>
+    <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">"</span><span style="color:#D20">not development!</span><span style="color:#710">"</span></span>
+  <span style="color:#080;font-weight:bold">end</span>
+<span style="color:#080;font-weight:bold">end</span>
+</pre></div>
+</div>
+</div>
 
-既定メソッド、`development?`、`test?`および`production?`を、現在の環境設定を確認するために使えます。
+<a name='%E3%82%A8%E3%83%A9%E3%83%BC%E3%83%8F%E3%83%B3%E3%83%89%E3%83%AA%E3%83%B3%E3%82%B0(Error%20Handling)'></a>
+<h2>エラーハンドリング(Error Handling)</h2>
 
-~~~~ruby
-get '/' do
-  if settings.development?
-    "development!"
-  else
-    "not development!"
-  end
-end
-~~~~
+<p>エラーハンドラはルーティングおよびbeforeフィルタと同じコンテキストで実行されます。すなわちこれは、<code>haml</code>、<code>erb</code>、<code>halt</code>といった便利なものが全て使えることを意味します。</p>
 
-## エラーハンドリング(Error Handling)
+<a name='%E6%9C%AA%E6%A4%9C%E5%87%BA(Not%20Found)'></a>
+<h3>未検出(Not Found)</h3>
 
-エラーハンドラはルーティングおよびbeforeフィルタと同じコンテキストで実行されます。すなわちこれは、`haml`、`erb`、`halt`といった便利なものが全て使えることを意味します。
+<p><code>Sinatra::NotFound</code>例外が発生したとき、またはレスポンスのステータスコードが404のときに、<code>not_found</code>ハンドラが発動します。</p>
 
-### 未検出(Not Found)
+<div>
+<div class="CodeRay">
+  <div class="code"><pre>not_found <span style="color:#080;font-weight:bold">do</span>
+  <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">ファイルが存在しません</span><span style="color:#710">'</span></span>
+<span style="color:#080;font-weight:bold">end</span>
+</pre></div>
+</div>
+</div>
 
-`Sinatra::NotFound`例外が発生したとき、またはレスポンスのステータスコードが404のときに、`not_found`ハンドラが発動します。
+<a name='%E3%82%A8%E3%83%A9%E3%83%BC(Error)'></a>
+<h3>エラー(Error)</h3>
 
-~~~~ruby
-not_found do
-  'ファイルが存在しません'
-end
-~~~~
+<p><code>error</code>ハンドラはルーティングブロックまたはフィルタ内で例外が発生したときはいつでも発動します。例外オブジェクトはRack変数<code>sinatra.error</code>から取得できます。</p>
 
-### エラー(Error)
+<div>
+<div class="CodeRay">
+  <div class="code"><pre>error <span style="color:#080;font-weight:bold">do</span>
+  <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">エラーが発生しました。 - </span><span style="color:#710">'</span></span> + env[<span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">sinatra.error</span><span style="color:#710">'</span></span>].name
+<span style="color:#080;font-weight:bold">end</span>
+</pre></div>
+</div>
+</div>
 
-`error`ハンドラはルーティングブロックまたはフィルタ内で例外が発生したときはいつでも発動します。例外オブジェクトはRack変数`sinatra.error`から取得できます。
+<p>エラーをカスタマイズする場合は、</p>
 
-~~~~ruby
-error do
-  'エラーが発生しました。 - ' + env['sinatra.error'].name
-end
-~~~~
+<div>
+<div class="CodeRay">
+  <div class="code"><pre>error <span style="color:#036;font-weight:bold">MyCustomError</span> <span style="color:#080;font-weight:bold">do</span>
+  <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">エラーメッセージ...</span><span style="color:#710">'</span></span> + env[<span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">sinatra.error</span><span style="color:#710">'</span></span>].message
+<span style="color:#080;font-weight:bold">end</span>
+</pre></div>
+</div>
+</div>
 
-エラーをカスタマイズする場合は、
+<p>と書いておいて、下記のように呼び出します。</p>
 
-~~~~ruby
-error MyCustomError do
-  'エラーメッセージ...' + env['sinatra.error'].message
-end
-~~~~
+<div>
+<div class="CodeRay">
+  <div class="code"><pre>get <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">/</span><span style="color:#710">'</span></span> <span style="color:#080;font-weight:bold">do</span>
+  raise <span style="color:#036;font-weight:bold">MyCustomError</span>, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">何かがまずかったようです</span><span style="color:#710">'</span></span>
+<span style="color:#080;font-weight:bold">end</span>
+</pre></div>
+</div>
+</div>
 
-と書いておいて、下記のように呼び出します。
+<p>そうするとこうなります。</p>
 
-~~~~ruby
-get '/' do
-  raise MyCustomError, '何かがまずかったようです'
-end
-~~~~
+<pre><code>エラーメッセージ... 何かがまずかったようです
+</code></pre>
 
-そうするとこうなります。
+<p>あるいは、ステータスコードに対応するエラーハンドラを設定することもできます。</p>
 
-~~~~
-エラーメッセージ... 何かがまずかったようです
-~~~~
+<div>
+<div class="CodeRay">
+  <div class="code"><pre>error <span style="color:#00D">403</span> <span style="color:#080;font-weight:bold">do</span>
+  <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">Access forbidden</span><span style="color:#710">'</span></span>
+<span style="color:#080;font-weight:bold">end</span>
 
-あるいは、ステータスコードに対応するエラーハンドラを設定することもできます。
+get <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">/secret</span><span style="color:#710">'</span></span> <span style="color:#080;font-weight:bold">do</span>
+  <span style="color:#00D">403</span>
+<span style="color:#080;font-weight:bold">end</span>
+</pre></div>
+</div>
+</div>
 
-~~~~ruby
-error 403 do
-  'Access forbidden'
-end
+<p>範囲指定もできます。</p>
 
-get '/secret' do
-  403
-end
-~~~~
+<div>
+<div class="CodeRay">
+  <div class="code"><pre>error <span style="color:#00D">400</span>..<span style="color:#00D">510</span> <span style="color:#080;font-weight:bold">do</span>
+  <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">Boom</span><span style="color:#710">'</span></span>
+<span style="color:#080;font-weight:bold">end</span>
+</pre></div>
+</div>
+</div>
 
-範囲指定もできます。
+<p>Sinatraを開発環境の下で実行している場合は、特別な<code>not_found</code>および<code>error</code>ハンドラが導入され、これは親切なスタックトレースと追加のデバッギング情報をブラウザに表示します。</p>
 
-~~~~ruby
-error 400..510 do
-  'Boom'
-end
-~~~~
+<a name='Rack%E3%83%9F%E3%83%89%E3%83%AB%E3%82%A6%E3%82%A7%E3%82%A2(Rack%20Middleware)'></a>
+<h2>Rackミドルウェア(Rack Middleware)</h2>
 
-Sinatraを開発環境の下で実行している場合は、特別な`not_found`および`error`ハンドラが導入され、これは親切なスタックトレースと追加のデバッギング情報をブラウザに表示します。
+<p>SinatraはRuby製Webフレームワークのミニマルな標準的インタフェースである<a href="http://rack.rubyforge.org/">Rack</a>上に構築されています。アプリケーションデベロッパーにとってRackにおける最も興味深い機能は、「ミドルウェア(middleware)」をサポートしていることであり、これは、サーバとアプリケーションとの間に置かれ、HTTPリクエスト/レスポンスを監視および/または操作することで、各種の汎用的機能を提供するコンポーネントです。</p>
 
+<p>Sinatraはトップレベルの<code>use</code>メソッドを通して、Rackミドルウェアパイプラインの構築を楽にします。</p>
 
-## Rackミドルウェア(Rack Middleware)
+<div>
+<div class="CodeRay">
+  <div class="code"><pre>require <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">sinatra</span><span style="color:#710">'</span></span>
+require <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">my_custom_middleware</span><span style="color:#710">'</span></span>
 
-SinatraはRuby製Webフレームワークのミニマルな標準的インタフェースである[Rack](http://rack.rubyforge.org/)上に構築されています。アプリケーションデベロッパーにとってRackにおける最も興味深い機能は、「ミドルウェア(middleware)」をサポートしていることであり、これは、サーバとアプリケーションとの間に置かれ、HTTPリクエスト/レスポンスを監視および/または操作することで、各種の汎用的機能を提供するコンポーネントです。
+use <span style="color:#036;font-weight:bold">Rack</span>::<span style="color:#036;font-weight:bold">Lint</span>
+use <span style="color:#036;font-weight:bold">MyCustomMiddleware</span>
 
-Sinatraはトップレベルの`use`メソッドを通して、Rackミドルウェアパイプラインの構築を楽にします。
+get <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">/hello</span><span style="color:#710">'</span></span> <span style="color:#080;font-weight:bold">do</span>
+  <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">Hello World</span><span style="color:#710">'</span></span>
+<span style="color:#080;font-weight:bold">end</span>
+</pre></div>
+</div>
+</div>
 
-~~~~ruby
-require 'sinatra'
-require 'my_custom_middleware'
+<p><code>use</code>の文法は、<a href="http://rack.rubyforge.org/doc/classes/Rack/Builder.html">Rack::Builder</a>DSLで定義されているそれ（rackupファイルで最もよく使われる）と同じです。例えば <code>use</code>メソッドは複数の引数、そしてブロックも取ることができます。</p>
 
-use Rack::Lint
-use MyCustomMiddleware
+<div>
+<div class="CodeRay">
+  <div class="code"><pre>use <span style="color:#036;font-weight:bold">Rack</span>::<span style="color:#036;font-weight:bold">Auth</span>::<span style="color:#036;font-weight:bold">Basic</span> <span style="color:#080;font-weight:bold">do</span> |username, password|
+  username == <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">admin</span><span style="color:#710">'</span></span> &amp;&amp; password == <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">secret</span><span style="color:#710">'</span></span>
+<span style="color:#080;font-weight:bold">end</span>
+</pre></div>
+</div>
+</div>
 
-get '/hello' do
-  'Hello World'
-end
-~~~~
+<p>Rackは、ロギング、デバッギング、URLルーティング、認証、セッション管理など、多様な標準的ミドルウェアを共に配布されています。Sinatraはその多くのコンポーネントを自動で使うよう基本設定されているため、通常、それらを<code>use</code>で明示的に指定する必要はありません。</p>
 
-`use`の文法は、[Rack::Builder](http://rack.rubyforge.org/doc/classes/Rack/Builder.html)DSLで定義されているそれ（rackupファイルで最もよく使われる）と同じです。例えば `use`メソッドは複数の引数、そしてブロックも取ることができます。
+<p>便利なミドルウェアを以下で見つけられます。</p>
 
-~~~~ruby
-use Rack::Auth::Basic do |username, password|
-  username == 'admin' &amp;&amp; password == 'secret'
-end
-~~~~
+<p><a href="https://github.com/rack/rack/tree/master/lib/rack">rack</a>、
+<a href="https://github.com/rack/rack-contrib#readm">rack-contrib</a>、
+または<a href="https://github.com/rack/rack/wiki/List-of-Middleware">Rack wiki</a>。</p>
 
-Rackは、ロギング、デバッギング、URLルーティング、認証、セッション管理など、多様な標準的ミドルウェアを共に配布されています。Sinatraはその多くのコンポーネントを自動で使うよう基本設定されているため、通常、それらを`use`で明示的に指定する必要はありません。
+<a name='%E3%83%86%E3%82%B9%E3%83%88(Testing)'></a>
+<h2>テスト(Testing)</h2>
 
-便利なミドルウェアを以下で見つけられます。
+<p>SinatraでのテストはRackベースのテストライブラリまたはフレームワークを使って書くことができます。<a href="http://rdoc.info/github/brynary/rack-test/master/frames">Rack::Test</a>をお薦めします。</p>
 
-[rack](https://github.com/rack/rack/tree/master/lib/rack)、
-[rack-contrib](https://github.com/rack/rack-contrib#readm)、
-または[Rack wiki](https://github.com/rack/rack/wiki/List-of-Middleware)。
+<div>
+<div class="CodeRay">
+  <div class="code"><pre>require <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">my_sinatra_app</span><span style="color:#710">'</span></span>
+require <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">test/unit</span><span style="color:#710">'</span></span>
+require <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">rack/test</span><span style="color:#710">'</span></span>
 
-## テスト(Testing)
+<span style="color:#080;font-weight:bold">class</span> <span style="color:#B06;font-weight:bold">MyAppTest</span> &lt; <span style="color:#036;font-weight:bold">Test</span>::<span style="color:#036;font-weight:bold">Unit</span>::<span style="color:#036;font-weight:bold">TestCase</span>
+  include <span style="color:#036;font-weight:bold">Rack</span>::<span style="color:#036;font-weight:bold">Test</span>::<span style="color:#036;font-weight:bold">Methods</span>
 
-SinatraでのテストはRackベースのテストライブラリまたはフレームワークを使って書くことができます。[Rack::Test](http://rdoc.info/github/brynary/rack-test/master/frames)をお薦めします。
+  <span style="color:#080;font-weight:bold">def</span> <span style="color:#06B;font-weight:bold">app</span>
+    <span style="color:#036;font-weight:bold">Sinatra</span>::<span style="color:#036;font-weight:bold">Application</span>
+  <span style="color:#080;font-weight:bold">end</span>
 
-~~~~ruby
-require 'my_sinatra_app'
-require 'test/unit'
-require 'rack/test'
+  <span style="color:#080;font-weight:bold">def</span> <span style="color:#06B;font-weight:bold">test_my_default</span>
+    get <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">/</span><span style="color:#710">'</span></span>
+    assert_equal <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">Hello World!</span><span style="color:#710">'</span></span>, last_response.body
+  <span style="color:#080;font-weight:bold">end</span>
 
-class MyAppTest &lt; Test::Unit::TestCase
-  include Rack::Test::Methods
+  <span style="color:#080;font-weight:bold">def</span> <span style="color:#06B;font-weight:bold">test_with_params</span>
+    get <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">/meet</span><span style="color:#710">'</span></span>, <span style="color:#A60">:name</span> =&gt; <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">Frank</span><span style="color:#710">'</span></span>
+    assert_equal <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">Hello Frank!</span><span style="color:#710">'</span></span>, last_response.body
+  <span style="color:#080;font-weight:bold">end</span>
 
-  def app
-    Sinatra::Application
-  end
+  <span style="color:#080;font-weight:bold">def</span> <span style="color:#06B;font-weight:bold">test_with_rack_env</span>
+    get <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">/</span><span style="color:#710">'</span></span>, {}, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">HTTP_USER_AGENT</span><span style="color:#710">'</span></span> =&gt; <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">Songbird</span><span style="color:#710">'</span></span>
+    assert_equal <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">"</span><span style="color:#D20">Songbirdを使ってます!</span><span style="color:#710">"</span></span>, last_response.body
+  <span style="color:#080;font-weight:bold">end</span>
+<span style="color:#080;font-weight:bold">end</span>
+</pre></div>
+</div>
+</div>
 
-  def test_my_default
-    get '/'
-    assert_equal 'Hello World!', last_response.body
-  end
+<p>ノート: モジュラースタイルでSinatraを使う場合は、上記<code>Sinatra::Application</code>をアプリケーションのクラス名に置き換えてください。</p>
 
-  def test_with_params
-    get '/meet', :name =&gt; 'Frank'
-    assert_equal 'Hello Frank!', last_response.body
-  end
+<a name='Sinatra::Base%20-%20%E3%83%9F%E3%83%89%E3%83%AB%E3%82%A6%E3%82%A7%E3%82%A2%E3%80%81%E3%83%A9%E3%82%A4%E3%83%96%E3%83%A9%E3%83%AA%E3%81%8A%E3%82%88%E3%81%B3%E3%83%A2%E3%82%B8%E3%83%A5%E3%83%A9%E3%83%BC%E3%82%A2%E3%83%97%E3%83%AA'></a>
+<h2>Sinatra::Base - ミドルウェア、ライブラリおよびモジュラーアプリ</h2>
 
-  def test_with_rack_env
-    get '/', {}, 'HTTP_USER_AGENT' =&gt; 'Songbird'
-    assert_equal "Songbirdを使ってます!", last_response.body
-  end
-end
-~~~~
+<p>軽量なアプリケーションであれば、トップレベルでアプリケーションを定義していくことはうまくいきますが、再利用性可能なコンポーネント、例えばRackミドルウェア、RailsのMetal、サーバコンポーネントを含むシンプルなライブラリ、あるいはSinatraの拡張プログラムを構築するような場合、これは無視できない欠点を持つものとなります。トップレベルは、軽量なアプリケーションのスタイルにおける設定（例えば、単一のアプリケーションファイル、<code>./public</code>および<code>./views</code>ディレクトリ、ロギング、例外詳細ページなど）を仮定しています。そこで<code>Sinatra::Base</code>の出番です。</p>
 
-ノート: モジュラースタイルでSinatraを使う場合は、上記`Sinatra::Application`をアプリケーションのクラス名に置き換えてください。
+<div>
+<div class="CodeRay">
+  <div class="code"><pre>require <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">sinatra/base</span><span style="color:#710">'</span></span>
 
-## Sinatra::Base - ミドルウェア、ライブラリおよびモジュラーアプリ
+<span style="color:#080;font-weight:bold">class</span> <span style="color:#B06;font-weight:bold">MyApp</span> &lt; <span style="color:#036;font-weight:bold">Sinatra</span>::<span style="color:#036;font-weight:bold">Base</span>
+  set <span style="color:#A60">:sessions</span>, <span style="color:#069">true</span>
+  set <span style="color:#A60">:foo</span>, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">bar</span><span style="color:#710">'</span></span>
 
-軽量なアプリケーションであれば、トップレベルでアプリケーションを定義していくことはうまくいきますが、再利用性可能なコンポーネント、例えばRackミドルウェア、RailsのMetal、サーバコンポーネントを含むシンプルなライブラリ、あるいはSinatraの拡張プログラムを構築するような場合、これは無視できない欠点を持つものとなります。トップレベルは、軽量なアプリケーションのスタイルにおける設定（例えば、単一のアプリケーションファイル、`./public`および`./views`ディレクトリ、ロギング、例外詳細ページなど）を仮定しています。そこで`Sinatra::Base`の出番です。
+  get <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">/</span><span style="color:#710">'</span></span> <span style="color:#080;font-weight:bold">do</span>
+    <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">Hello world!</span><span style="color:#710">'</span></span>
+  <span style="color:#080;font-weight:bold">end</span>
+<span style="color:#080;font-weight:bold">end</span>
+</pre></div>
+</div>
+</div>
 
-~~~~ruby
-require 'sinatra/base'
+<p><code>Sinatra::Base</code>のサブクラスで利用できるメソッドは、トップレベルDSLで利用できるものと全く同じです。ほとんどのトップレベルで記述されたアプリは、以下の２点を修正することで<code>Sinatra::Base</code>コンポーネントに変えることができます。</p>
 
-class MyApp &lt; Sinatra::Base
-  set :sessions, true
-  set :foo, 'bar'
+<ul>
+<li>
+<code>sinatra</code>の代わりに<code>sinatra/base</code>を読み込む
+(そうしない場合、SinatraのDSLメソッドの全てがmainの名前空間にインポートされます)</li>
+  <li>ルーティング、エラーハンドラ、フィルタ、オプションを<code>Sinatra::Base</code>のサブクラスに書く</li>
+</ul>
+<p><code>Sinatra::Base</code>はまっさらです。ビルトインサーバを含む、ほとんどのオプションがデフォルトで無効になっています。利用可能なオプションとその挙動の詳細については<a href="http://sinatra.github.com/configuration.html">Configuring Settings</a>(英語)をご覧下さい。</p>
 
-  get '/' do
-    'Hello world!'
-  end
-end
-~~~~
+<p>もしもクラシックスタイルと同じような挙動のアプリケーションをトップレベルで定義させる必要があれば、<code>Sinatra::Application</code>をサブクラス化させてください。</p>
 
-`Sinatra::Base`のサブクラスで利用できるメソッドは、トップレベルDSLで利用できるものと全く同じです。ほとんどのトップレベルで記述されたアプリは、以下の２点を修正することで`Sinatra::Base`コンポーネントに変えることができます。
+<div>
+<div class="CodeRay">
+  <div class="code"><pre>require <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">"</span><span style="color:#D20">sinatra/base</span><span style="color:#710">"</span></span>
 
-* `sinatra`の代わりに`sinatra/base`を読み込む
-  (そうしない場合、SinatraのDSLメソッドの全てがmainの名前空間にインポートされます)
-* ルーティング、エラーハンドラ、フィルタ、オプションを`Sinatra::Base`のサブクラスに書く
+<span style="color:#080;font-weight:bold">class</span> <span style="color:#B06;font-weight:bold">MyApp</span> &lt; <span style="color:#036;font-weight:bold">Sinatra</span>::<span style="color:#036;font-weight:bold">Application</span>
+  get <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">"</span><span style="color:#D20">/</span><span style="color:#710">"</span></span> <span style="color:#080;font-weight:bold">do</span>
+    <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">Hello world!</span><span style="color:#710">'</span></span>
+  <span style="color:#080;font-weight:bold">end</span>
+<span style="color:#080;font-weight:bold">end</span>
+</pre></div>
+</div>
+</div>
 
-`Sinatra::Base`はまっさらです。ビルトインサーバを含む、ほとんどのオプションがデフォルトで無効になっています。利用可能なオプションとその挙動の詳細については[Configuring Settings](http://sinatra.github.com/configuration.html)(英語)をご覧下さい。
+<a name='%E3%83%A2%E3%82%B8%E3%83%A5%E3%83%A9%E3%83%BC%E3%82%B9%E3%82%BF%E3%82%A4%E3%83%AB%20vs%20%E3%82%AF%E3%83%A9%E3%83%83%E3%82%B7%E3%83%83%E3%82%AF%E3%82%B9%E3%82%BF%E3%82%A4%E3%83%AB'></a>
+<h3>モジュラースタイル vs クラッシックスタイル</h3>
 
-もしもクラシックスタイルと同じような挙動のアプリケーションをトップレベルで定義させる必要があれば、`Sinatra::Application`をサブクラス化させてください。
+<p>一般的認識と違って、クラッシックスタイルを使うことに問題はなにもありません。それがそのアプリケーションに合っているのであれば、モジュラーアプリケーションに移行する必要はありません。</p>
 
-~~~~ruby
-require "sinatra/base"
+<p>モジュラースタイルを使わずにクラッシックスタイルを使った場合の一番の不利な点は、Rubyプロセスごとにただ一つのSinatraアプリケーションしか持てない点です。複数が必要な場合はモジュラースタイルに移行してください。モジュラースタイルとクラッシックスタイルを混合できないということはありません。</p>
 
-class MyApp &lt; Sinatra::Application
-  get "/" do
-    'Hello world!'
-  end
-end
-~~~~
-
-### モジュラースタイル vs クラッシックスタイル
-
-一般的認識と違って、クラッシックスタイルを使うことに問題はなにもありません。それがそのアプリケーションに合っているのであれば、モジュラーアプリケーションに移行する必要はありません。
-
-モジュラースタイルを使わずにクラッシックスタイルを使った場合の一番の不利な点は、Rubyプロセスごとにただ一つのSinatraアプリケーションしか持てない点です。複数が必要な場合はモジュラースタイルに移行してください。モジュラースタイルとクラッシックスタイルを混合できないということはありません。
-
-一方のスタイルから他方へ移行する場合、デフォルト設定がわずかに異なる点に注意が必要です。
+<p>一方のスタイルから他方へ移行する場合、デフォルト設定がわずかに異なる点に注意が必要です。</p>
 
 <table>
 <tr>
@@ -2666,262 +2745,321 @@ end
     <td>true</td>
   </tr>
 </table>
+<a name='%E3%83%A2%E3%82%B8%E3%83%A5%E3%83%A9%E3%83%BC%E3%82%A2%E3%83%97%E3%83%AA%E3%82%B1%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%81%AE%E6%8F%90%E4%BE%9B'></a>
+<h3>モジュラーアプリケーションの提供</h3>
 
-### モジュラーアプリケーションの提供
+<p>モジュラーアプリケーションを開始、つまり<code>run!</code>を使って開始させる二種類のやり方があります。</p>
 
-モジュラーアプリケーションを開始、つまり`run!`を使って開始させる二種類のやり方があります。
+<div>
+<div class="CodeRay">
+  <div class="code"><pre><span style="color:#777"># my_app.rb</span>
+require <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">sinatra/base</span><span style="color:#710">'</span></span>
 
-~~~~ruby
-# my_app.rb
-require 'sinatra/base'
+<span style="color:#080;font-weight:bold">class</span> <span style="color:#B06;font-weight:bold">MyApp</span> &lt; <span style="color:#036;font-weight:bold">Sinatra</span>::<span style="color:#036;font-weight:bold">Base</span>
+  <span style="color:#777"># ... アプリケーションのコードを書く ...</span>
 
-class MyApp &lt; Sinatra::Base
-  # ... アプリケーションのコードを書く ...
+  <span style="color:#777"># Rubyファイルが直接実行されたらサーバを立ち上げる</span>
+  run! <span style="color:#080;font-weight:bold">if</span> app_file == <span style="color:#d70">$0</span>
+<span style="color:#080;font-weight:bold">end</span>
+</pre></div>
+</div>
+</div>
 
-  # Rubyファイルが直接実行されたらサーバを立ち上げる
-  run! if app_file == $0
-end
-~~~~
+<p>として、次のように起動するか、</p>
 
-として、次のように起動するか、
+<div>
+<div class="CodeRay">
+  <div class="code"><pre>ruby my_app.rb
+</pre></div>
+</div>
+</div>
 
-~~~~shell
-ruby my_app.rb
-~~~~
+<p>または、Rackハンドラを使えるようにする<code>config.ru</code>ファイルを書いて、</p>
 
-または、Rackハンドラを使えるようにする`config.ru`ファイルを書いて、
+<div>
+<div class="CodeRay">
+  <div class="code"><pre><span style="color:#777"># config.ru (rackupで起動)</span>
+require <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">./my_app</span><span style="color:#710">'</span></span>
+run <span style="color:#036;font-weight:bold">MyApp</span>
+</pre></div>
+</div>
+</div>
 
-~~~~ruby
-# config.ru (rackupで起動)
-require './my_app'
-run MyApp
-~~~~
+<p>起動します。</p>
 
-起動します。
+<div>
+<div class="CodeRay">
+  <div class="code"><pre>rackup -p 4567
+</pre></div>
+</div>
+</div>
 
-~~~~shell
-rackup -p 4567
-~~~~
+<a name='config.ru%E3%82%92%E7%94%A8%E3%81%84%E3%81%9F%E3%82%AF%E3%83%A9%E3%83%83%E3%82%B7%E3%83%83%E3%82%AF%E3%82%B9%E3%82%BF%E3%82%A4%E3%83%AB%E3%82%A2%E3%83%97%E3%83%AA%E3%82%B1%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%81%AE%E4%BD%BF%E7%94%A8'></a>
+<h3>config.ruを用いたクラッシックスタイルアプリケーションの使用</h3>
 
-### config.ruを用いたクラッシックスタイルアプリケーションの使用
+<p>アプリケーションファイルと、</p>
 
-アプリケーションファイルと、
+<div>
+<div class="CodeRay">
+  <div class="code"><pre><span style="color:#777"># app.rb</span>
+require <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">sinatra</span><span style="color:#710">'</span></span>
 
-~~~~ruby
-# app.rb
-require 'sinatra'
+get <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">/</span><span style="color:#710">'</span></span> <span style="color:#080;font-weight:bold">do</span>
+  <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">Hello world!</span><span style="color:#710">'</span></span>
+<span style="color:#080;font-weight:bold">end</span>
+</pre></div>
+</div>
+</div>
 
-get '/' do
-  'Hello world!'
-end
-~~~~
+<p>対応する<code>config.ru</code>を書きます。</p>
 
-対応する`config.ru`を書きます。
+<div>
+<div class="CodeRay">
+  <div class="code"><pre>require <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">./app</span><span style="color:#710">'</span></span>
+run <span style="color:#036;font-weight:bold">Sinatra</span>::<span style="color:#036;font-weight:bold">Application</span>
+</pre></div>
+</div>
+</div>
 
-~~~~ruby
-require './app'
-run Sinatra::Application
-~~~~
+<a name='config.ru%E3%81%AF%E3%81%84%E3%81%A4%E4%BD%BF%E3%81%86%E3%81%AE%E3%81%8B%EF%BC%9F'></a>
+<h3>config.ruはいつ使うのか？</h3>
 
-### config.ruはいつ使うのか？
+<p><code>config.ru</code>ファイルは、以下の場合に適しています。</p>
 
-`config.ru`ファイルは、以下の場合に適しています。
+<ul>
+<li>異なるRackハンドラ(Passenger, Unicorn, Herokuなど)でデプロイしたいとき</li>
+  <li>
+<code>Sinatra::Base</code>の複数のサブクラスを使いたいとき</li>
+  <li>Sinatraをミドルウェアとして利用し、エンドポイントとしては利用しないとき</li>
+</ul>
+<p><strong>モジュラースタイルに移行したという理由だけで、<code>config.ru</code>に移行する必要はなく、<code>config.ru</code>で起動するためにモジュラースタイルを使う必要はありません。</strong></p>
 
-* 異なるRackハンドラ(Passenger, Unicorn, Herokuなど)でデプロイしたいとき
-* `Sinatra::Base`の複数のサブクラスを使いたいとき
-* Sinatraをミドルウェアとして利用し、エンドポイントとしては利用しないとき
+<a name='Sinatra%E3%81%AE%E3%83%9F%E3%83%89%E3%83%AB%E3%82%A6%E3%82%A7%E3%82%A2%E3%81%A8%E3%81%97%E3%81%A6%E3%81%AE%E5%88%A9%E7%94%A8'></a>
+<h3>Sinatraのミドルウェアとしての利用</h3>
 
-**モジュラースタイルに移行したという理由だけで、`config.ru`に移行する必要はなく、`config.ru`で起動するためにモジュラースタイルを使う必要はありません。**
+<p>Sinatraは他のRackミドルウェアを利用することができるだけでなく、
+全てのSinatraアプリケーションは、それ自体ミドルウェアとして別のRackエンドポイントの前に追加することが可能です。</p>
 
-### Sinatraのミドルウェアとしての利用
+<p>このエンドポイントには、別のSinatraアプリケーションまたは他のRackベースのアプリケーション(Rails/Ramaze/Camping/…)が用いられるでしょう。</p>
 
-Sinatraは他のRackミドルウェアを利用することができるだけでなく、
-全てのSinatraアプリケーションは、それ自体ミドルウェアとして別のRackエンドポイントの前に追加することが可能です。
+<div>
+<div class="CodeRay">
+  <div class="code"><pre>require <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">sinatra/base</span><span style="color:#710">'</span></span>
 
-このエンドポイントには、別のSinatraアプリケーションまたは他のRackベースのアプリケーション(Rails/Ramaze/Camping/…)が用いられるでしょう。
+<span style="color:#080;font-weight:bold">class</span> <span style="color:#B06;font-weight:bold">LoginScreen</span> &lt; <span style="color:#036;font-weight:bold">Sinatra</span>::<span style="color:#036;font-weight:bold">Base</span>
+  enable <span style="color:#A60">:sessions</span>
 
-~~~~ruby
-require 'sinatra/base'
+  get(<span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">/login</span><span style="color:#710">'</span></span>) { haml <span style="color:#A60">:login</span> }
 
-class LoginScreen &lt; Sinatra::Base
-  enable :sessions
+  post(<span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">/login</span><span style="color:#710">'</span></span>) <span style="color:#080;font-weight:bold">do</span>
+    <span style="color:#080;font-weight:bold">if</span> params[<span style="color:#A60">:name</span>] = <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">admin</span><span style="color:#710">'</span></span> <span style="color:#080;font-weight:bold">and</span> params[<span style="color:#A60">:password</span>] = <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">admin</span><span style="color:#710">'</span></span>
+      session[<span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">user_name</span><span style="color:#710">'</span></span>] = params[<span style="color:#A60">:name</span>]
+    <span style="color:#080;font-weight:bold">else</span>
+      redirect <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">/login</span><span style="color:#710">'</span></span>
+    <span style="color:#080;font-weight:bold">end</span>
+  <span style="color:#080;font-weight:bold">end</span>
+<span style="color:#080;font-weight:bold">end</span>
 
-  get('/login') { haml :login }
+<span style="color:#080;font-weight:bold">class</span> <span style="color:#B06;font-weight:bold">MyApp</span> &lt; <span style="color:#036;font-weight:bold">Sinatra</span>::<span style="color:#036;font-weight:bold">Base</span>
+  <span style="color:#777"># ミドルウェアはbeforeフィルタの前に実行される</span>
+  use <span style="color:#036;font-weight:bold">LoginScreen</span>
 
-  post('/login') do
-    if params[:name] = 'admin' and params[:password] = 'admin'
-      session['user_name'] = params[:name]
-    else
-      redirect '/login'
-    end
-  end
-end
+  before <span style="color:#080;font-weight:bold">do</span>
+    <span style="color:#080;font-weight:bold">unless</span> session[<span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">user_name</span><span style="color:#710">'</span></span>]
+      halt <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">"</span><span style="color:#D20">アクセスは拒否されました。&lt;a href='/login'&gt;ログイン&lt;/a&gt;してください。</span><span style="color:#710">"</span></span>
+    <span style="color:#080;font-weight:bold">end</span>
+  <span style="color:#080;font-weight:bold">end</span>
 
-class MyApp &lt; Sinatra::Base
-  # ミドルウェアはbeforeフィルタの前に実行される
-  use LoginScreen
+  get(<span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">/</span><span style="color:#710">'</span></span>) { <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">"</span><span style="color:#D20">Hello </span><span style="background-color:hsla(0,0%,0%,0.07);color:black"><span style="font-weight:bold;color:#666">#{</span>session[<span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">user_name</span><span style="color:#710">'</span></span>]<span style="font-weight:bold;color:#666">}</span></span><span style="color:#D20">.</span><span style="color:#710">"</span></span> }
+<span style="color:#080;font-weight:bold">end</span>
+</pre></div>
+</div>
+</div>
 
-  before do
-    unless session['user_name']
-      halt "アクセスは拒否されました。<a href="/login">ログイン</a>してください。"
-    end
-  end
+<a name='%E5%8B%95%E7%9A%84%E3%81%AA%E3%82%A2%E3%83%97%E3%83%AA%E3%82%B1%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%81%AE%E7%94%9F%E6%88%90'></a>
+<h3>動的なアプリケーションの生成</h3>
 
-  get('/') { "Hello #{session['user_name']}." }
-end
-~~~~
+<p>新しいアプリケーションを実行時に、定数に割り当てることなく生成したくなる場合があるでしょう。<code>Sinatra.new</code>を使えばそれができます。</p>
 
-### 動的なアプリケーションの生成
-
-新しいアプリケーションを実行時に、定数に割り当てることなく生成したくなる場合があるでしょう。`Sinatra.new`を使えばそれができます。
-
-~~~~ruby
-require 'sinatra/base'
-my_app = Sinatra.new { get('/') { "hi" } }
+<div>
+<div class="CodeRay">
+  <div class="code"><pre>require <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">sinatra/base</span><span style="color:#710">'</span></span>
+my_app = <span style="color:#036;font-weight:bold">Sinatra</span>.new { get(<span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">/</span><span style="color:#710">'</span></span>) { <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">"</span><span style="color:#D20">hi</span><span style="color:#710">"</span></span> } }
 my_app.run!
-~~~~
+</pre></div>
+</div>
+</div>
 
-これは省略できる引数として、それが継承するアプリケーションを取ります。
+<p>これは省略できる引数として、それが継承するアプリケーションを取ります。</p>
 
-~~~~ruby
-# config.ru (rackupで起動)
-require 'sinatra/base'
+<div>
+<div class="CodeRay">
+  <div class="code"><pre><span style="color:#777"># config.ru (rackupで起動)</span>
+require <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">sinatra/base</span><span style="color:#710">'</span></span>
 
-controller = Sinatra.new do
-  enable :logging
-  helpers MyHelpers
-end
+controller = <span style="color:#036;font-weight:bold">Sinatra</span>.new <span style="color:#080;font-weight:bold">do</span>
+  enable <span style="color:#A60">:logging</span>
+  helpers <span style="color:#036;font-weight:bold">MyHelpers</span>
+<span style="color:#080;font-weight:bold">end</span>
 
-map('/a') do
-  run Sinatra.new(controller) { get('/') { 'a' } }
-end
+map(<span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">/a</span><span style="color:#710">'</span></span>) <span style="color:#080;font-weight:bold">do</span>
+  run <span style="color:#036;font-weight:bold">Sinatra</span>.new(controller) { get(<span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">/</span><span style="color:#710">'</span></span>) { <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">a</span><span style="color:#710">'</span></span> } }
+<span style="color:#080;font-weight:bold">end</span>
 
-map('/b') do
-  run Sinatra.new(controller) { get('/') { 'b' } }
-end
-~~~~
+map(<span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">/b</span><span style="color:#710">'</span></span>) <span style="color:#080;font-weight:bold">do</span>
+  run <span style="color:#036;font-weight:bold">Sinatra</span>.new(controller) { get(<span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">/</span><span style="color:#710">'</span></span>) { <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">b</span><span style="color:#710">'</span></span> } }
+<span style="color:#080;font-weight:bold">end</span>
+</pre></div>
+</div>
+</div>
 
-これは特にSinatraのextensionをテストするときや、Sinatraを自身のライブラリで利用する場合に役立ちます。
+<p>これは特にSinatraのextensionをテストするときや、Sinatraを自身のライブラリで利用する場合に役立ちます。</p>
 
-これはまた、Sinatraをミドルウェアとして利用することを極めて簡単にします。
+<p>これはまた、Sinatraをミドルウェアとして利用することを極めて簡単にします。</p>
 
-~~~~ruby
-require 'sinatra/base'
+<div>
+<div class="CodeRay">
+  <div class="code"><pre>require <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">sinatra/base</span><span style="color:#710">'</span></span>
 
-use Sinatra do
-  get('/') { ... }
-end
+use <span style="color:#036;font-weight:bold">Sinatra</span> <span style="color:#080;font-weight:bold">do</span>
+  get(<span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">/</span><span style="color:#710">'</span></span>) { ... }
+<span style="color:#080;font-weight:bold">end</span>
 
-run RailsProject::Application
-~~~~
+run <span style="color:#036;font-weight:bold">RailsProject</span>::<span style="color:#036;font-weight:bold">Application</span>
+</pre></div>
+</div>
+</div>
 
-## スコープとバインディング(Scopes and Binding)
+<a name='%E3%82%B9%E3%82%B3%E3%83%BC%E3%83%97%E3%81%A8%E3%83%90%E3%82%A4%E3%83%B3%E3%83%87%E3%82%A3%E3%83%B3%E3%82%B0(Scopes%20and%20Binding)'></a>
+<h2>スコープとバインディング(Scopes and Binding)</h2>
 
-現在のスコープはどのメソッドや変数が利用可能かを決定します。
+<p>現在のスコープはどのメソッドや変数が利用可能かを決定します。</p>
 
-### アプリケーション/クラスのスコープ
+<a name='%E3%82%A2%E3%83%97%E3%83%AA%E3%82%B1%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3/%E3%82%AF%E3%83%A9%E3%82%B9%E3%81%AE%E3%82%B9%E3%82%B3%E3%83%BC%E3%83%97'></a>
+<h3>アプリケーション/クラスのスコープ</h3>
 
-全てのSinatraアプリケーションはSinatra::Baseのサブクラスに相当します。
-もしトップレベルDSLを利用しているならば(`require 'sinatra'`)このクラスはSinatra::Applicationであり、
+<p>全てのSinatraアプリケーションはSinatra::Baseのサブクラスに相当します。
+もしトップレベルDSLを利用しているならば(<code>require 'sinatra'</code>)このクラスはSinatra::Applicationであり、
 そうでなければ、あなたが明示的に作成したサブクラスです。
-クラスレベルでは`get`や`before`のようなメソッドを持っています。
-しかし`request`や`session`オブジェクトには、全てのリクエストに対する単一のアプリケーションクラスがあるだけなので、アクセスできません。
+クラスレベルでは<code>get</code>や<code>before</code>のようなメソッドを持っています。
+しかし<code>request</code>や<code>session</code>オブジェクトには、全てのリクエストに対する単一のアプリケーションクラスがあるだけなので、アクセスできません。</p>
 
-`set`によって作られたオプションはクラスレベルのメソッドです。
+<p><code>set</code>によって作られたオプションはクラスレベルのメソッドです。</p>
 
-~~~~ruby
-class MyApp &lt; Sinatra::Base
-  # アプリケーションスコープの中だよ!
-  set :foo, 42
-  foo # =&gt; 42
+<div>
+<div class="CodeRay">
+  <div class="code"><pre><span style="color:#080;font-weight:bold">class</span> <span style="color:#B06;font-weight:bold">MyApp</span> &lt; <span style="color:#036;font-weight:bold">Sinatra</span>::<span style="color:#036;font-weight:bold">Base</span>
+  <span style="color:#777"># アプリケーションスコープの中だよ!</span>
+  set <span style="color:#A60">:foo</span>, <span style="color:#00D">42</span>
+  foo <span style="color:#777"># =&gt; 42</span>
 
-  get '/foo' do
-    # もうアプリケーションスコープの中にいないよ!
-  end
-end
-~~~~
+  get <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">/foo</span><span style="color:#710">'</span></span> <span style="color:#080;font-weight:bold">do</span>
+    <span style="color:#777"># もうアプリケーションスコープの中にいないよ!</span>
+  <span style="color:#080;font-weight:bold">end</span>
+<span style="color:#080;font-weight:bold">end</span>
+</pre></div>
+</div>
+</div>
 
-次の場所ではアプリケーションスコープバインディングを持ちます。
+<p>次の場所ではアプリケーションスコープバインディングを持ちます。</p>
 
-* アプリケーションクラス本体
-* 拡張によって定義されたメソッド
-* `helpers`に渡されたブロック
-* `set`の値として使われるProcまたはブロック
-* `Sinatra.new`に渡されたブロック
+<ul>
+<li>アプリケーションクラス本体</li>
+  <li>拡張によって定義されたメソッド</li>
+  <li>
+<code>helpers</code>に渡されたブロック</li>
+  <li>
+<code>set</code>の値として使われるProcまたはブロック</li>
+  <li>
+<code>Sinatra.new</code>に渡されたブロック</li>
+</ul>
+<p>このスコープオブジェクト(クラス)は次のように利用できます。</p>
 
-このスコープオブジェクト(クラス)は次のように利用できます。
+<ul>
+<li>configureブロックに渡されたオブジェクト経由(<code>configure { |c| ... }</code>)</li>
+  <li>リクエストスコープの中での<code>settings</code>
+</li>
+</ul>
+<a name='%E3%83%AA%E3%82%AF%E3%82%A8%E3%82%B9%E3%83%88/%E3%82%A4%E3%83%B3%E3%82%B9%E3%82%BF%E3%83%B3%E3%82%B9%E3%81%AE%E3%82%B9%E3%82%B3%E3%83%BC%E3%83%97'></a>
+<h3>リクエスト/インスタンスのスコープ</h3>
 
-* configureブロックに渡されたオブジェクト経由(`configure { |c| ... }`)
-* リクエストスコープの中での`settings`
+<p>やってくるリクエストごとに、あなたのアプリケーションクラスの新しいインスタンスが作成され、全てのハンドラブロックがそのスコープで実行されます。
+このスコープの内側からは<code>request</code>や<code>session</code>オブジェクトにアクセスすることができ、<code>erb</code>や<code>haml</code>のようなレンダリングメソッドを呼び出すことができます。
+リクエストスコープの内側からは、<code>settings</code>ヘルパーによってアプリケーションスコープにアクセスすることができます。</p>
 
-### リクエスト/インスタンスのスコープ
+<div>
+<div class="CodeRay">
+  <div class="code"><pre><span style="color:#080;font-weight:bold">class</span> <span style="color:#B06;font-weight:bold">MyApp</span> &lt; <span style="color:#036;font-weight:bold">Sinatra</span>::<span style="color:#036;font-weight:bold">Base</span>
+  <span style="color:#777"># アプリケーションスコープの中だよ!</span>
+  get <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">/define_route/:name</span><span style="color:#710">'</span></span> <span style="color:#080;font-weight:bold">do</span>
+    <span style="color:#777"># '/define_route/:name'のためのリクエストスコープ</span>
+    <span style="color:#33B">@value</span> = <span style="color:#00D">42</span>
 
-やってくるリクエストごとに、あなたのアプリケーションクラスの新しいインスタンスが作成され、全てのハンドラブロックがそのスコープで実行されます。
-このスコープの内側からは`request`や`session`オブジェクトにアクセスすることができ、`erb`や`haml`のようなレンダリングメソッドを呼び出すことができます。
-リクエストスコープの内側からは、`settings`ヘルパーによってアプリケーションスコープにアクセスすることができます。
+    settings.get(<span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">"</span><span style="color:#D20">/</span><span style="background-color:hsla(0,0%,0%,0.07);color:black"><span style="font-weight:bold;color:#666">#{</span>params[<span style="color:#A60">:name</span>]<span style="font-weight:bold;color:#666">}</span></span><span style="color:#710">"</span></span>) <span style="color:#080;font-weight:bold">do</span>
+      <span style="color:#777"># "/#{params[:name]}"のためのリクエストスコープ</span>
+      <span style="color:#33B">@value</span> <span style="color:#777"># =&gt; nil (not the same request)</span>
+    <span style="color:#080;font-weight:bold">end</span>
 
-~~~~ruby
-class MyApp &lt; Sinatra::Base
-  # アプリケーションスコープの中だよ!
-  get '/define_route/:name' do
-    # '/define_route/:name'のためのリクエストスコープ
-    @value = 42
+    <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">"</span><span style="color:#D20">ルーティングが定義された!</span><span style="color:#710">"</span></span>
+  <span style="color:#080;font-weight:bold">end</span>
+<span style="color:#080;font-weight:bold">end</span>
+</pre></div>
+</div>
+</div>
 
-    settings.get("/#{params[:name]}") do
-      # "/#{params[:name]}"のためのリクエストスコープ
-      @value # =&gt; nil (not the same request)
-    end
+<p>次の場所ではリクエストスコープバインディングを持ちます。</p>
 
-    "ルーティングが定義された!"
-  end
-end
-~~~~
+<ul>
+<li>get/head/post/put/delete/options/patch/link/unlink ブロック</li>
+  <li>before/after フィルタ</li>
+  <li>helper メソッド</li>
+  <li>テンプレート/ビュー</li>
+</ul>
+<a name='%E3%83%87%E3%83%AA%E3%82%B2%E3%83%BC%E3%83%88%E3%82%B9%E3%82%B3%E3%83%BC%E3%83%97'></a>
+<h3>デリゲートスコープ</h3>
 
-次の場所ではリクエストスコープバインディングを持ちます。
-
-* get/head/post/put/delete/options/patch/link/unlink ブロック
-* before/after フィルタ
-* helper メソッド
-* テンプレート/ビュー
-
-### デリゲートスコープ
-
-デリゲートスコープは、単にクラススコープにメソッドを転送します。
+<p>デリゲートスコープは、単にクラススコープにメソッドを転送します。
 しかしながら、クラスのバインディングを持っていないため、クラススコープと全く同じふるまいをするわけではありません。
 委譲すると明示的に示されたメソッドのみが利用可能であり、またクラススコープと変数/状態を共有することはできません(注:
-異なった`self`を持っています)。
-`Sinatra::Delegator.delegate :method_name`を呼び出すことによってデリゲートするメソッドを明示的に追加することができます。
+異なった<code>self</code>を持っています)。
+<code>Sinatra::Delegator.delegate :method_name</code>を呼び出すことによってデリゲートするメソッドを明示的に追加することができます。</p>
 
-次の場所ではデリゲートスコープを持ちます。
+<p>次の場所ではデリゲートスコープを持ちます。</p>
 
-* もし`require "sinatra"`しているならば、トップレベルバインディング
-* `Sinatra::Delegator` mixinでextendされたオブジェクト
+<ul>
+<li>もし<code>require "sinatra"</code>しているならば、トップレベルバインディング</li>
+  <li>
+<code>Sinatra::Delegator</code> mixinでextendされたオブジェクト</li>
+</ul>
+<p>コードをご覧ください: ここでは <a href="https://github.com/sinatra/sinatra/blob/ca06364/lib/sinatra/base.rb#L1609-1633">Sinatra::Delegator
+mixin</a>は<a href="https://github.com/sinatra/sinatra/blob/ca06364/lib/sinatra/main.rb#L28-30">mainオブジェクトにextendされています</a>。</p>
 
-コードをご覧ください: ここでは [Sinatra::Delegator
-mixin](https://github.com/sinatra/sinatra/blob/ca06364/lib/sinatra/base.rb#L1609-1633)は[mainオブジェクトにextendされています](https://github.com/sinatra/sinatra/blob/ca06364/lib/sinatra/main.rb#L28-30)。
+<a name='%E3%82%B3%E3%83%9E%E3%83%B3%E3%83%89%E3%83%A9%E3%82%A4%E3%83%B3'></a>
+<h2>コマンドライン</h2>
 
-## コマンドライン
+<p>Sinatraアプリケーションは直接実行できます。</p>
 
-Sinatraアプリケーションは直接実行できます。
+<div>
+<div class="CodeRay">
+  <div class="code"><pre>ruby myapp.rb [-h] [-x] [-e ENVIRONMENT] [-p PORT] [-o HOST] [-s HANDLER]
+</pre></div>
+</div>
+</div>
 
-~~~~shell
-ruby myapp.rb [-h] [-x] [-e ENVIRONMENT] [-p PORT] [-o HOST] [-s HANDLER]
-~~~~
+<p>オプション:</p>
 
-オプション:
-
-~~~~
--h # ヘルプ
+<pre><code>-h # ヘルプ
 -p # ポート指定(デフォルトは4567)
 -o # ホスト指定(デフォルトは0.0.0.0)
 -e # 環境を指定 (デフォルトはdevelopment)
 -s # rackserver/handlerを指定 (デフォルトはthin)
 -x # mutex lockを付ける (デフォルトはoff)
-~~~~
+</code></pre>
 
-## 必要環境
+<a name='%E5%BF%85%E8%A6%81%E7%92%B0%E5%A2%83'></a>
+<h2>必要環境</h2>
 
-次のRubyバージョンが公式にサポートされています。
+<p>次のRubyバージョンが公式にサポートされています。</p>
 
 <dl>
 <dt>Ruby 1.8.7</dt>
@@ -2956,115 +3094,152 @@ ruby myapp.rb [-h] [-x] [-e ENVIRONMENT] [-p PORT] [-o HOST] [-s HANDLER]
     <tt>gem install trinidad</tt>することが推奨されています。
   </dd>
 </dl>
+<p>開発チームは常に最新となるRubyバージョンに注視しています。</p>
 
-開発チームは常に最新となるRubyバージョンに注視しています。
+<p>次のRuby実装は公式にはサポートされていませんが、Sinatraが起動すると報告されています。</p>
 
-次のRuby実装は公式にはサポートされていませんが、Sinatraが起動すると報告されています。
+<ul>
+<li>JRubyとRubiniusの古いバージョン</li>
+  <li>Ruby Enterprise Edition</li>
+  <li>MacRuby, Maglev, IronRuby</li>
+  <li>Ruby 1.9.0と1.9.1 (これらの使用はお薦めしません)</li>
+</ul>
+<p>公式サポートをしないという意味は、問題がそこだけで起こり、サポートされているプラットフォーム上では起きない場合に、開発チームはそれはこちら側の問題ではないとみなすということです。</p>
 
-* JRubyとRubiniusの古いバージョン
-* Ruby Enterprise Edition
-* MacRuby, Maglev, IronRuby
-* Ruby 1.9.0と1.9.1 (これらの使用はお薦めしません)
+<p>開発チームはまた、ruby-head(最新となる2.1.0)に対しCIを実行していますが、それが一貫して動くようになるまで何も保証しません。2.1.0が完全にサポートされればその限りではありません。</p>
 
-公式サポートをしないという意味は、問題がそこだけで起こり、サポートされているプラットフォーム上では起きない場合に、開発チームはそれはこちら側の問題ではないとみなすということです。
+<p>Sinatraは、利用するRuby実装がサポートしているオペレーティングシステム上なら動作するはずです。</p>
 
-開発チームはまた、ruby-head(最新となる2.1.0)に対しCIを実行していますが、それが一貫して動くようになるまで何も保証しません。2.1.0が完全にサポートされればその限りではありません。
+<p>MacRubyを使う場合は、<code>gem install control_tower</code>してください。</p>
 
-Sinatraは、利用するRuby実装がサポートしているオペレーティングシステム上なら動作するはずです。
+<p>Sinatraは現在、Cardinal、SmallRuby、BlueRubyまたは1.8.7以前のバージョンのRuby上では動作しません。</p>
 
-MacRubyを使う場合は、`gem install control_tower`してください。
+<a name='%E6%9C%80%E6%96%B0%E9%96%8B%E7%99%BA%E7%89%88'></a>
+<h2>最新開発版</h2>
 
-Sinatraは現在、Cardinal、SmallRuby、BlueRubyまたは1.8.7以前のバージョンのRuby上では動作しません。
+<p>Sinatraの最新開発版のコードを使いたい場合は、マスターブランチに対してアプリケーションを走らせて構いません。ある程度安定しています。また、適宜プレリリース版gemをpushしているので、</p>
 
-## 最新開発版
+<div>
+<div class="CodeRay">
+  <div class="code"><pre>gem install sinatra --pre
+</pre></div>
+</div>
+</div>
 
-Sinatraの最新開発版のコードを使いたい場合は、マスターブランチに対してアプリケーションを走らせて構いません。ある程度安定しています。また、適宜プレリリース版gemをpushしているので、
+<p>すれば、最新の機能のいくつかを利用できます。</p>
 
-~~~~shell
-gem install sinatra --pre
-~~~~
+<a name='Bundler%E3%82%92%E4%BD%BF%E3%81%86%E5%A0%B4%E5%90%88'></a>
+<h3>Bundlerを使う場合</h3>
 
-すれば、最新の機能のいくつかを利用できます。
+<p>最新のSinatraでアプリケーションを動作させたい場合には、<a href="http://gembundler.com/">Bundler</a>を使うのがお薦めのやり方です。</p>
 
-### Bundlerを使う場合
+<p>まず、Bundlerがなければそれをインストールします。</p>
 
-最新のSinatraでアプリケーションを動作させたい場合には、[Bundler](http://gembundler.com/)を使うのがお薦めのやり方です。
+<div>
+<div class="CodeRay">
+  <div class="code"><pre>gem install bundler
+</pre></div>
+</div>
+</div>
 
-まず、Bundlerがなければそれをインストールします。
+<p>そして、プロジェクトのディレクトリで、<code>Gemfile</code>を作ります。</p>
 
-~~~~shell
-gem install bundler
-~~~~
+<div>
+<div class="CodeRay">
+  <div class="code"><pre>source <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">https://rubygems.org</span><span style="color:#710">'</span></span>
+gem <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">sinatra</span><span style="color:#710">'</span></span>, <span style="color:#A60">:github</span> =&gt; <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">"</span><span style="color:#D20">sinatra/sinatra</span><span style="color:#710">"</span></span>
 
-そして、プロジェクトのディレクトリで、`Gemfile`を作ります。
+<span style="color:#777"># 他の依存ライブラリ</span>
+gem <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">haml</span><span style="color:#710">'</span></span>                    <span style="color:#777"># Hamlを使う場合</span>
+gem <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">activerecord</span><span style="color:#710">'</span></span>, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">~&gt; 3.0</span><span style="color:#710">'</span></span>  <span style="color:#777"># ActiveRecord 3.xが必要かもしれません</span>
+</pre></div>
+</div>
+</div>
 
-~~~~ruby
-source 'https://rubygems.org'
-gem 'sinatra', :github =&gt; "sinatra/sinatra"
+<p>ノート: <code>Gemfile</code>にアプリケーションの依存ライブラリのすべてを並べる必要があります。しかし、Sinatraが直接依存するもの(RackおよびTile)はBundlerによって自動的に取り込まれ、追加されます。</p>
 
-# 他の依存ライブラリ
-gem 'haml'                    # Hamlを使う場合
-gem 'activerecord', '~&gt; 3.0'  # ActiveRecord 3.xが必要かもしれません
-~~~~
+<p>これで、以下のようにしてアプリケーションを起動することができます。</p>
 
-ノート: `Gemfile`にアプリケーションの依存ライブラリのすべてを並べる必要があります。しかし、Sinatraが直接依存するもの(RackおよびTile)はBundlerによって自動的に取り込まれ、追加されます。
+<div>
+<div class="CodeRay">
+  <div class="code"><pre>bundle exec ruby myapp.rb
+</pre></div>
+</div>
+</div>
 
-これで、以下のようにしてアプリケーションを起動することができます。
+<a name='%E7%9B%B4%E6%8E%A5%E7%B5%84%E3%81%BF%E8%BE%BC%E3%82%80%E5%A0%B4%E5%90%88'></a>
+<h3>直接組み込む場合</h3>
 
-~~~~shell
-bundle exec ruby myapp.rb
-~~~~
+<p>ローカルにクローンを作って、<code>sinatra/lib</code>ディレクトリを<code>$LOAD_PATH</code>に追加してアプリケーションを起動します。</p>
 
-### 直接組み込む場合
-
-ローカルにクローンを作って、`sinatra/lib`ディレクトリを`$LOAD_PATH`に追加してアプリケーションを起動します。
-
-~~~~shell
-cd myapp
+<div>
+<div class="CodeRay">
+  <div class="code"><pre>cd myapp
 git clone git://github.com/sinatra/sinatra.git
 ruby -I sinatra/lib myapp.rb
-~~~~
+</pre></div>
+</div>
+</div>
 
-追ってSinatraのソースを更新する方法。
+<p>追ってSinatraのソースを更新する方法。</p>
 
-~~~~shell
-cd myapp/sinatra
+<div>
+<div class="CodeRay">
+  <div class="code"><pre>cd myapp/sinatra
 git pull
-~~~~
+</pre></div>
+</div>
+</div>
 
-### グローバル環境にインストールする場合
+<a name='%E3%82%B0%E3%83%AD%E3%83%BC%E3%83%90%E3%83%AB%E7%92%B0%E5%A2%83%E3%81%AB%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB%E3%81%99%E3%82%8B%E5%A0%B4%E5%90%88'></a>
+<h3>グローバル環境にインストールする場合</h3>
 
-Sinatraのgemを自身でビルドすることもできます。
+<p>Sinatraのgemを自身でビルドすることもできます。</p>
 
-~~~~shell
-git clone git://github.com/sinatra/sinatra.git
+<div>
+<div class="CodeRay">
+  <div class="code"><pre>git clone git://github.com/sinatra/sinatra.git
 cd sinatra
 rake sinatra.gemspec
 rake install
-~~~~
+</pre></div>
+</div>
+</div>
 
-gemをルートとしてインストールする場合は、最後のステップはこうなります。
+<p>gemをルートとしてインストールする場合は、最後のステップはこうなります。</p>
 
-~~~~shell
-sudo rake install
-~~~~
+<div>
+<div class="CodeRay">
+  <div class="code"><pre>sudo rake install
+</pre></div>
+</div>
+</div>
 
-## バージョニング(Versioning)
+<a name='%E3%83%90%E3%83%BC%E3%82%B8%E3%83%A7%E3%83%8B%E3%83%B3%E3%82%B0(Versioning)'></a>
+<h2>バージョニング(Versioning)</h2>
 
-Sinatraは、[Semantic Versioning](http://semver.org/)におけるSemVerおよびSemVerTagの両方に準拠しています。
+<p>Sinatraは、<a href="http://semver.org/">Semantic Versioning</a>におけるSemVerおよびSemVerTagの両方に準拠しています。</p>
 
-## 参考文献
+<a name='%E5%8F%82%E8%80%83%E6%96%87%E7%8C%AE'></a>
+<h2>参考文献</h2>
 
-* [プロジェクトサイト](http://sinatra.github.com/) - ドキュメント、ニュース、他のリソースへのリンクがあります。
-* [プロジェクトに参加(貢献)する](http://sinatra.github.com/contributing.html) - バグレポート パッチの送信、サポートなど
-* [Issue tracker](http://github.com/sinatra/sinatra/issues)
-* [Twitter](http://twitter.com/sinatra)
-* [メーリングリスト](http://groups.google.com/group/sinatrarb/topics)
-* http://freenode.net上のIRC: [#sinatra](irc://chat.freenode.net/#sinatra)
-* [Sinatra Book](http://sinatra-book.gittr.com) クックブック、チュートリアル
-* [Sinatra Recipes](http://recipes.sinatrarb.com/) コミュニティによるレシピ集
-* http://rubydoc.info上のAPIドキュメント: [最新版(latest release)用](http://rubydoc.info/gems/sinatra)または[現在のHEAD用](http://rubydoc.info/github/sinatra/sinatra)
-* [CIサーバ](http://travis-ci.org/sinatra/sinatra)
-* [Greenbear Laboratory Rack日本語マニュアル](http://route477.net/w/RackReferenceJa.html)
-</dl>
+<ul>
+<li>
+<a href="http://sinatra.github.com/">プロジェクトサイト</a> - ドキュメント、ニュース、他のリソースへのリンクがあります。</li>
+  <li>
+<a href="http://sinatra.github.com/contributing.html">プロジェクトに参加(貢献)する</a> - バグレポート パッチの送信、サポートなど</li>
+  <li><a href="http://github.com/sinatra/sinatra/issues">Issue tracker</a></li>
+  <li><a href="http://twitter.com/sinatra">Twitter</a></li>
+  <li><a href="http://groups.google.com/group/sinatrarb/topics">メーリングリスト</a></li>
+  <li>http://freenode.net上のIRC: <a href="irc://chat.freenode.net/#sinatra">#sinatra</a>
+</li>
+  <li>
+<a href="http://sinatra-book.gittr.com">Sinatra Book</a> クックブック、チュートリアル</li>
+  <li>
+<a href="http://recipes.sinatrarb.com/">Sinatra Recipes</a> コミュニティによるレシピ集</li>
+  <li>http://rubydoc.info上のAPIドキュメント: <a href="http://rubydoc.info/gems/sinatra">最新版(latest release)用</a>または<a href="http://rubydoc.info/github/sinatra/sinatra">現在のHEAD用</a>
+</li>
+  <li><a href="http://travis-ci.org/sinatra/sinatra">CIサーバ</a></li>
+  <li><a href="http://route477.net/w/RackReferenceJa.html">Greenbear Laboratory Rack日本語マニュアル</a></li>
+</ul>
 </body></html>


### PR DESCRIPTION
`README.ja.html` is broken because of a missing HTML tag(</bt>) in the source(README.ja.md). I am requesting to be merged the fixed version to sinatra repo. So I rebuilt README.ja.html with a fixed README.ja.md as interim measure.
