### PR TITLE
Update faq.markdown with better link for book

### DIFF
--- a/faq.markdown
+++ b/faq.markdown
@@ -40,7 +40,7 @@ If you still want in-process reloading, check out [Sinatra::Reloader](/contrib/r
 What are my deployment options? {#deploy}
 -------------------------------
 
-See the [book](http://sinatra-book.gittr.com/#deployment).
+See the [book](https://github.com/sinatra/sinatra-book).
 
 How do I use sessions? {#sessions}
 ----------------------


### PR DESCRIPTION
The current book link (http://sinatra-book.gittr.com/#deployment) appears to be broken so I replaced it with the book's github repo (https://github.com/sinatra/sinatra-book).

Linking to the book's source doesn't seem like a great solution, just a temporary fix.