### PR TITLE
fixed broken link to old rubyforge link

### DIFF
--- a/faq.markdown
+++ b/faq.markdown
@@ -59,7 +59,7 @@ Sessions are disabled by default. You need to enable them and then use the
       session[:message]   # => 'Hello World!'
     end
 
-If you need to set additional parameters for sessions, like expiration date, use [`Rack::Session::Cookie`](http://rack.rubyforge.org/doc/classes/Rack/Session/Cookie.html) directly instead of `enable :sessions` (example from _Rack_ documentation):
+If you need to set additional parameters for sessions, like expiration date, use [`Rack::Session::Cookie`](http://www.rubydoc.info/github/rack/rack/Rack/Session/Cookie) directly instead of `enable :sessions` (example from _Rack_ documentation):
 
     use Rack::Session::Cookie, :key => 'rack.session',
                                :domain => 'foo.com',


### PR DESCRIPTION
rubyforge link was dead.  rubydoc.info link is canonical from Rack project now.
