### PR TITLE
Add metaflop.com to "in the wild", and some cleanup

### DIFF
--- a/wild.markdown
+++ b/wild.markdown
@@ -87,6 +87,7 @@ Applications {#apps}
 - [VDGB](http://vdgb.dk) - Subscription based online video training platform for schools and teachers
 - [The Myndflame Bucket](http://buckateers.com) - Innovative platform for Twitch.tv show to automatically collect donations from viewers, provide limited rewards and to encourage fellowship to continuously support the show through gamification
 - [Beathound](http://beathound.com) - helping you stay on top of new releases from the artists you love
+- [Metaflop](http://www.metaflop.com) An easy to use web application for generating and modulating your own fonts.
 
 Libraries and extensions {#libs}
 ------------------------

--- a/wild.markdown
+++ b/wild.markdown
@@ -10,7 +10,6 @@ We'll take care of the rest.
 
 Applications {#apps}
 ------------
-- [Flip Text](http://cedarcreekit.com/labs/flip_text) A simple app used to flip text upside down.
 - [SequenceServer](http://www.sequenceserver.com/) An easy-to-setup BLAST sequence search server
 - [Flickr Group Viewer](http://gv.vqvz.com) is a (nicer?) way to view photos in a flickr group -- [on GitHub](https://github.com/funkaoshi/gv.vqvz.com).
 - [OnBoard](http://dev.vemarsas.it/onboard/) a web interface to manage Linux-based network appliances.
@@ -19,7 +18,7 @@ Applications {#apps}
   tweets by attendees
 - [Integrity](http://integrityapp.com) the easy and fun
   Continuous Integration server
-- [Sum](https://sumapp.com) is an email-based budgeting application
+- [Sum](http://sumapp.com) is an email-based budgeting application
 - [Marley](https://github.com/karmi/marley) the blog engine
   without &lt;textareas&gt;
 - [Postview](https://github.com/codigorama/postview) a simple blog-engine that
@@ -27,7 +26,6 @@ Applications {#apps}
 - [Scanty](https://github.com/adamwiggins/scanty) an even more minimalist
   blogging engine
 - [Scanty using CouchDB](https://github.com/jtulloch/scanty/tree/master)
-- [Scanty using CouchDB 0.9.0a and CouchRest 0.16](https://github.com/norr/scanty/tree/master)
 - [Haze](https://github.com/madx/haze) a lightweight and minimalist blogging
   engine using flat text files.
 - [Wind](https://github.com/wagnerandrade/wind) HTML5 blog engine focused in a easy, extensible and fast admin.
@@ -63,14 +61,10 @@ Applications {#apps}
   provider based on OpenID
 - [Hancock Client](https://github.com/atmos/hancock-client/tree/master) Rack
   middleware client for the Hancock server, written in Sinatra
-- [Rails Searchable API Doc](http://railsapi.com/) runs on Sinatra
 - [Sinatra Saucer](https://github.com/angelic/sinatra_saucer) JRuby web application frontend for Flying Saucer, which converts XHTML into a PDF
 - [WineAdds](http://wineadds.com) micro-app that calculates common additions to wine
 - [Deltacloud](http://www.deltacloud.org) Deltacloud protects your apps from cloud API changes and incompatibilies. REST API is written using Sinatra
 - [Jaconda](http://jaconda.im) A simple team collaboration service that allows you to create chat rooms for groups through Gtalk/Jabber protocol. REST API is written in Sinatra
-- [Soxer](http://soxer.mutsu.org/) Soxer is a lean but infinitely extensible web publishing tool.
-- [SinMagick](http://blog.50projects.com/p/sinmagick-image-processing.html) a front-end for image processing and thumbnailing with flexible storage options.
-- [Fundry - Crowdfunding for Software Development](http://fundry.com) - Fundry is designed around software projects, helping developers get paid for developing new features, and enabling your community to pledge to get the features they want. The site and API (coming soon) is all written in Sinatra.
 - [Picky](https://github.com/floere/picky) - a fast &amp; clever semantic search engine.
 - [Headhunter](http://headhunter.heroku.com) - giving Twitter profile pics a permanent URL
 - [blitz.io](http://blitz.io) - Making load and performance testing a fun sport
@@ -78,12 +72,10 @@ Applications {#apps}
 - [Git-Webby](https://github.com/codigorama/git-webby) - Git Smart HTTP Ruby/Sinatra implementation with useful features.
 - [Trudy](https://github.com/quimarche/trudy) - A Nabaztag server.
 - [Markdown Tree](https://github.com/mil/markdown-tree) - Serve a Hierarchy of Markdown files simply (like mksite or other site generators, only dynamic)
-- [Fracture.it](http://fracture.it) URL shortening service \[[Source](https://github.com/michaelminter/fracture-url)\]
 - [streetart.io](http://itunes.com/app/streetartio) streetart.io allows you to share and discover interesting street art, public art and sculptures around you and your city. API is powered by Sinatra and Redis.
 - [TaskwarriorWeb](http://theunraveler.github.com/taskwarrior-web/) - A Sinatra-based web interface for the Taskwarrior todo application. Because being a neck-beard is only fun sometimes.
 - [Travis CI](https://travis-ci.org/) - Free Hosted Continuous Integration Platform for the Open Source Community
 - [Rank Captain](http://rankcaptain.com) - Keyword based mass landing page generator with live template editor
-- [Importrechner.ch](http://importrechner.ch) - Dynamic car import calculator and contract form generator based upon Sinatra & AngularJS
 - [VDGB](http://vdgb.dk) - Subscription based online video training platform for schools and teachers
 - [The Myndflame Bucket](http://buckateers.com) - Innovative platform for Twitch.tv show to automatically collect donations from viewers, provide limited rewards and to encourage fellowship to continuously support the show through gamification
 - [Beathound](http://beathound.com) - helping you stay on top of new releases from the artists you love
@@ -120,12 +112,8 @@ Libraries and extensions {#libs}
   implementation for Rack with extra sugar for Sinatra.
 - [Sinatra-REST](https://github.com/blindgaenger/sinatra-rest) generates RESTful
   routes for your models (ActiveRecord, DataMapper, Stone)
-- [R18n](http://r18n.rubyforge.org/#sinatra) Agnostic i18n library with Sinatra
-  extension.
 - [url\_for](https://github.com/emk/sinatra-url-for/) Construct absolute paths
   and full URLs for current application.
-- [WebIRC](https://github.com/andyherbert/WebIRC) Web-based IRC
-  client.
 - [content\_for](https://github.com/foca/sinatra-content-for) Rails-like `content_for`
   helper for your views (supports ERB and Haml.)
 - [Sinatra Effigy](https://github.com/croaky/sinatra-effigy) Sinatra extension
@@ -165,16 +153,12 @@ Websites {#sites}
   for hackers
 - [irclogger](http://irclogger.com) Logging urz IRC channel
   [#sinatra](http://irclogger.com/sinatra)
-- [URL Unwind](http://urlunwind.com) Don't get RickRolled again
-- [Tweetdreams](http://tweetdreams.org) Twitter dream journal
 - [Does Follow](http://doesfollow.com) Twitter tool for figuring out who
   follows whom
-- [portfolio.quirkey.com](http://portfolio.quirkey.com/)
 - [Gusg.us](http://gusg.us/) Blog - Ridding the long bus
 - [Deleanotes](http://delanotes.com/)
 - [themoviedb.org](http://api.themoviedb.org/) The name says it all :)
 - [columnlog](https://github.com/quirkey/columnlog) Tiny feed fetching app
-- [Your Fiveruns Dashboard](http://dash.fiveruns.com)
 - [IronRuby](http://ironruby.info) Watch their great stats here
 - [MooURL](http://moourl.com/) The web's cutest URL shortening service
 - [FlexCode](http://flexcode.com.br/) iPhone development
@@ -194,18 +178,13 @@ Websites {#sites}
 - [A Good Company](http://www.weareagoodcompany.com/) An awesome little portfolio for a great design company.
 - [dbpedia lite](http://dbpedialite.org/) takes some of the structured data in Wikipedia and presents it as Linked Data ([Source](https://github.com/njh/dbpedialite/)).
 - [Evan Lecklider](http://lecklider.com/) Website showing off work, code examples and experiments built with Sinatra and Compass.
-- [Brightspoke.com](http://www.brightspoke.com/) matches people with bicycles.
-- [Kittygram](http://kittygram.heroku.com/) shows cute cat photos from around the world.
 - [happens.co.za](http://www.happens.co.za/) Add countdown times for any "happening" or event and share it with others.
 - [DarkArts Studios](http://www.darkarts.co.za/) Projects and source code of Clive Crous
 - [Ant genome database](http://fourmidable.unil.ch)
-- [GitHub High Scores](http://github-high-scores.heroku.com) A fun way to rank GitHub repository contributors in a 8-bit, 80's-tastic aracdey viewing environment.
 - [Conker Software](http://conkersoftware.co.uk) Micro-company of Tom Philip that makes Web, Android and Boxee apps.
 - [Similander](http://similar.heroku.com) extracts keywords from a given URL to find similar pages ([Source](https://github.com/ema/similander)).
-- [Sombras de Papel](http://sombrasdepapel.com/en/) Website of a pop-rock band from Barcelona (Spain) entirely made using Sinatra + HTML5. There's also an automatic mobile site.
-- [streetart.io](http://streetart.io) streetart.io allows you to share and discover interesting street art, public art and sculptures around you and your city. The website is a sinatra app which pulls data via the API.
+- [Sombras de Papel](http://sombrasdepapel.com) Website of a pop-rock band from Barcelona (Spain) entirely made using Sinatra + HTML5. There's also an automatic mobile site.
 - [Scrum Primer](http://www.scrumprimer.org) - A short introduction to Scrum. The code is at [Scrum Primer @ Github](https://github.com/basvodde/scrumprimer). Also uses [r18n for Sinatra](https://github.com/ai/r18n)
-- [Jembatan Keledai](http://jembatankeledai.com) A collection of mnemonics in Indonesian.
 - [hike.io](http://hike.io) - The best place to find beautiful hikes online. Hike.io is free, open source, and anyone can make an edit. [(Source)](https://github.com/zaknelson/hike.io)
 - [Goodnot.es](http://goodnot.es) - Listen to the 5 most popular songs of any artist of band. [(Source)](https://github.com/javonharper/goodnotes)
 
@@ -218,20 +197,15 @@ Companies using Sinatra {#biz}
 - [LinkedIn](http://www.linkedin.com/)
 - [National Security Agency](http://www.nsa.gov/)
 - [Agency Rainford](http://agencyrainford.com)
-- [Songbird](http://getsongbird.com)
 - [Curbed Network](http://curbed.com)
-- [Meticulo](http://www.meticulo.com/)
-- [Rock-n-code](http://www.rock-n-code.com/)
 - [Solutious](http://solutious.com/)
 - [Centro](http://www.centro.net/)
 - [Apartment Therapy](http://www.apartmenttherapy.com)
 - [Inventive Labs](http://inventivelabs.com.au/)
 - [ENTP](http://entp.com)
-- [FiveRuns](http://fiveruns.com)
 - [Engine Yard](http://engineyard.com)
 - [Citrusbyte](http://www.citrusbyte.com/)
 - [Lomographic Society International](http://beta.lomography.com)
-- [Swipht Technologies](http://www.swipht.com)
 - [Nth Metal Interactive](http://nthmetal.com)
 - [Osborne Brook](http://osbornebrook.co.uk)
 - [Robot Mode](http://robotmo.de)
@@ -242,14 +216,12 @@ Companies using Sinatra {#biz}
 - [A Good Company](http://www.weareagoodcompany.com)
 - [Ylastic](http://ylastic.com)
 - [Fork](http://usefork.com)
-- [Tractor Feed](http://tractorfeed.org)
 - [Ant genomics database - Fourmidable](http://antgenomes.org/)
 - [Mu Dynamics](http://www.mudynamics.com)
 - [Scribble Squad](http://www.scribblesquad.com)
 - [Stanford](http://www.stanford.edu)
 - [Hiboux](http://www.hiboux.ca)
 - [PentesterLab](http://www.pentesterlab.com)
-- [Cedar Creek IT Solutions](http://cedarcreekit.com)
 - [Animoto](http://www.animoto.com)
 - [Red Hat](http://www.redhat.com)
 - [Travis CI](https://travis-ci.com)


### PR DESCRIPTION
I added the entry *metaflop.com* to the "in the wild" page. While doing this I noticed
some outdated entries and cleaned up a little bit. I'm open to clean up even further, but I'd
like to discuss this first (may result in separate pull-request).

Primary tasks

* [x] Add metaflop.com
* [x] Remove obsolete projects (404, 500 errors)

Further tasks that may make sense, up for discussion:

* [ ] Remove deprecated (deprecated notice on github) projects, or mark them as such
* [ ] Remove projects that haven't had any updates for a certain period of time, or move to a separate section
* [ ] Remove projects that are part of sinatra-contrib (sinatra-config-file, sinatra-content-for, sinatra-namespace, sinatra-reloader, sinatra-test-helper, big_band)
* [ ] Make a clearer distinction between "Websites" and "Applications", or merge them
* [ ] Remove duplicates (travis-ci, linkedin, weareagoodcompany, antgenomes)
* [ ] Sort entries alphabetically
* [ ] Update layout, e.g. use a table with columns "name", "description", "url", "source code"