### PR TITLE
Fixes read cookies example

### DIFF
--- a/_includes/sinatra-cookies.html
+++ b/_includes/sinatra-cookies.html
@@ -8,7 +8,7 @@
 <p>Allows you to read cookies:</p>
 
 <pre>get &#39;/&#39; do
-  &quot;value: #{cookie[:something]}&quot;
+  &quot;value: #{cookies[:something]}&quot;
 end</pre>
 
 <p>And of course to write cookies:</p>


### PR DESCRIPTION
There was a small typo in the example, it used "cookie" instead of "cookies".