### PR TITLE
miscellaneous bits

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Sinatra Website / Documentation
 ===============================
 
 This repo contains the Sinatra website and documentation sources published
-at [http://sinatra.github.com/](http://sinatra.github.com/).
+at [http://www.sinatrarb.com/](http://www.sinatrarb.com/).
 
 Working Locally
 ---------------

--- a/Thorfile
+++ b/Thorfile
@@ -7,7 +7,7 @@ class Blog < Thor
     layout: post
     title: TITLE
     author: YOUR NAME
-    author_url: http://sinatra.github.com/
+    author_url: http://www.sinatrarb.com/
     publish_date: #{Time.now.strftime('%A, %B %d, %Y')}
     ---
 

--- a/_includes/README.html
+++ b/_includes/README.html
@@ -850,7 +850,7 @@ template, you almost always want to pass locals to it.</p>
   </tr>
 </table>
 
-<p>It is not possible to call methods from markdown, nor to pass locals to it.
+<p>It is not possible to call methods from Markdown, nor to pass locals to it.
 You therefore will usually use it in combination with another rendering
 engine:</p>
 
@@ -893,7 +893,7 @@ template than for the layout by passing the <code>:layout_engine</code> option.<
   </tr>
 </table>
 
-<p>It is not possible to call methods from textile, nor to pass locals to it. You
+<p>It is not possible to call methods from Textile, nor to pass locals to it. You
 therefore will usually use it in combination with another rendering engine:</p>
 
 <div class="highlighter-coderay">
@@ -935,7 +935,7 @@ template than for the layout by passing the <code>:layout_engine</code> option.<
   </tr>
 </table>
 
-<p>It is not possible to call methods from rdoc, nor to pass locals to it. You
+<p>It is not possible to call methods from RDoc, nor to pass locals to it. You
 therefore will usually use it in combination with another rendering engine:</p>
 
 <div class="highlighter-coderay">
@@ -1077,7 +1077,7 @@ always want to pass locals to it.</p>
   </tr>
 </table>
 
-<p>It is not possible to call methods from creole, nor to pass locals to it. You
+<p>It is not possible to call methods from Creole, nor to pass locals to it. You
 therefore will usually use it in combination with another rendering engine:</p>
 
 <div class="highlighter-coderay">

--- a/_includes/README.html
+++ b/_includes/README.html
@@ -2965,7 +2965,7 @@ of <code>Sinatra::Base</code>.</li>
 
 <p><code>Sinatra::Base</code> is a blank slate. Most options are disabled by default,
 including the built-in server. See
-<a href="http://www.sinatrarb.com/configuration.html">Configuring Settings</a>
+<a href="configuration.html">Configuring Settings</a>
 for details on available options and their behavior. If you want
 behavior more similar to when you define your app at the top level (also
 known as Classic style), you

--- a/documentation.markdown
+++ b/documentation.markdown
@@ -171,7 +171,7 @@ Screencasts and Presentations
 ### [Sinatra, rack and middleware](http://www.slideshare.net/benschwarz/sinatra-rack-and-middleware-1509268)
 
 Ben Schwarz presents Sinatra and his realisations of its inner workings in regard to 
-rack and rack middlware at Melbourne RORO shortly after Railsconf (US).
+rack and rack middleware at Melbourne RORO shortly after Railsconf (US).
 
 ### [RubyConf 08: Lightweight Web Services](http://rubyconf2008.confreaks.com/lightweight-web-services.html)
 

--- a/extensions.markdown
+++ b/extensions.markdown
@@ -159,7 +159,7 @@ Extending The DSL (class) Context with `Sinatra.register`
 
 Extensions can also extend Sinatra's class level DSL using the
 `Sinatra.register` method. Here's an extension that adds a
-`block_links_from` macro that checks the referer on each request for
+`block_links_from` macro that checks the referer (sic) on each request for
 a app provided pattern and sends back a `403 Forbidden` response when
 a match is detected:
 

--- a/wild.markdown
+++ b/wild.markdown
@@ -105,7 +105,7 @@ Libraries and extensions {#libs}
   Base app with DataMapper, Haml and RSpec. Fork and build.
 - [Sinatra OAuth Provider](https://github.com/eddanger/sinatra-oauth-provider)
   an [OAuth](http://oauth.net) provider implemented with Sinatra
-- [Spork](https://github.com/deadprogrammer/spork) Executes some aynchronous
+- [Spork](https://github.com/deadprogrammer/spork) Executes some asynchronous
   code using Sinatra running under Passenger
 - [Retweet](https://github.com/zapnap/retweet) Create Twitter apps like
   tweetdreams.org with ease


### PR DESCRIPTION
* I think it makes sense to consistently capitalize things, unless they're in \<code>...\</code>
* sinatra.github.com redirects, so there's no point in using that in pages (unless they're specifically about getting the repo as opposed to loading the site)
* There is both en-us and en-gb in this repo, I haven't tried to enforce this
* While I do have a tool to find typos, I didn't use it here, this was a manual spot-check