### PR TITLE
add link to rubydocs.org to documentation

### DIFF
--- a/documentation.markdown
+++ b/documentation.markdown
@@ -153,6 +153,10 @@ See the `CHANGES` file included for release notes about each release:
 
 RDoc documentation courtesy of `rubydoc.info`.
 
+### [Searchable API Documentation](https://rubydocs.org?search=sinatra)
+
+Searchable SDoc documentation courtesy of `rubydocs.org`.
+
 ### [In the Wild](/wild.html)
 
 List of applications, libraries, websites and companies using Sinatra.


### PR DESCRIPTION
Hi @zzak! 😄 

I added Sinatra to RubyDocs.org, so I thought it would be nice to link to it from the Sinatra documentation page.

Cheers,
Manuel