### PR TITLE
Use herokuapp link for sinatra book

### DIFF
--- a/book.html
+++ b/book.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <title>Sinatra Book</title>
-    <meta http-equiv='refresh' content='0;http://sinatra-book.gittr.com/'>
+    <meta http-equiv='refresh' content='0;http://sinatra-org-book.herokuapp.com/'>
   </head>
   <body>
     <p>
-      <a href="http://sinatra-book.gittr.com/">The Sinatra Book has moved</a>
+      <a href="http://sinatra-org-book.herokuapp.com/">The Sinatra Book has moved</a>
     </p>
   </body>
 </html>

--- a/contributing.markdown
+++ b/contributing.markdown
@@ -62,7 +62,7 @@ GitHub to track patch requests.
   is where the website sources are managed. There are almost always people in
   `#sinatra` that are happy to discuss, apply, and publish website patches.
 
-* [The Book](http://sinatra-book.gittr.com/) has its own [git
+* [The Book](http://sinatra-org-book.herokuapp.com/) has its own [git
   repository](http://github.com/sinatra/sinatra-book/) and build process but is
   managed the same as the website and project codebase.
 


### PR DESCRIPTION
Furthermore, all links including `gittr` are dead. I did not change those, as I don't know where they've been migrated to.