### PR TITLE
Add exclude rules to Jekyll config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,4 @@ gem "thor"
 gem 'bourbon'
 gem 'neat'
 gem 'sass'
+gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,7 @@ GEM
       sass (>= 3.3)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
+    rake (11.2.2)
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
@@ -53,9 +54,10 @@ DEPENDENCIES
   kramdown
   neat
   nokogiri (>= 1.5.9)
+  rake
   rdoc (~> 3.9.0)
   sass
   thor
 
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/_config.yml
+++ b/_config.yml
@@ -3,4 +3,5 @@ markdown: kramdown
 port:    4000
 host:    127.0.0.1
 baseurl: /sinatra.github.com
+exclude: [ 'vendor', 'Rakefile', 'Thorfile', 'Gemfile', 'Gemfile.lock', 'node_modules']
 


### PR DESCRIPTION
This fixes the problem where Jekyll tries to compile _every_ markdown file
that's in the current hierarchy, which includes `vendor` directory.

* Added Rake to Gemfile

I'm still getting some compilation problems when I run `rake regen`. Will debug
that problem later, but I think this is a nice to have for folks who install
the gems to vendor directory instead of globally installing them.