### PR TITLE
Make example on home usable without quote change

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,9 +17,9 @@ id: home
 
   <div id='syntax-wrapper'>
   <pre id='sinatra-joke'><code id='sinatra-syntax'>
-    <span id='require'>require </span><span class='code-quotes'>‘</span><span class='code-text'>sinatra</span><span class='code-quotes'>’</span>
-    <span id='code-method-name'>get </span><span class='code-quotes'>‘</span><span class='code-text'>/frank-says</span><span class='code-quotes'>’ </span><span class='code-block'>do</span>
-      <span class='code-quotes'>‘</span><span class='code-text'>Put this in your pipe & smoke it!</span><span class='code-quotes'>’</span>
+    <span id='require'>require </span><span class='code-quotes'>'</span><span class='code-text'>sinatra</span><span class='code-quotes'>'</span>
+    <span id='code-method-name'>get </span><span class='code-quotes'>'</span><span class='code-text'>/frank-says</span><span class='code-quotes'>' </span><span class='code-block'>do</span>
+      <span class='code-quotes'>'</span><span class='code-text'>Put this in your pipe & smoke it!</span><span class='code-quotes'>'</span>
     <span class='code-block'>end</span>
   </code>
   </pre>


### PR DESCRIPTION
The example on the homepage currently uses curly quotes.  While curly quotes are more attractive, straight quotes are more friendly to new users because they can just ~~copy-and-paste the example and run it~~ put it in their pipe and smoke it.