### PR TITLE
Use more specific URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Run the test server:
 
 Changes are immediately available at:
 
-    http://localhost:4000
+    http://localhost:4000/sinatra.github.com/
 
 Contributing
 ------------


### PR DESCRIPTION
After running `rake server`, the instructions currently direct you to `http://localhost:4000`.

That URL returns a 404 because the base path is set to `/sinatra.github.com` in `_config.yml`.

This commit changes the URL to include that path.
