### PR TITLE
Tweak line-height for lists and code examples

### DIFF
--- a/css/development/legend.css
+++ b/css/development/legend.css
@@ -201,3 +201,9 @@ p code.highlighter-rouge {
   padding: 3px;
   color: #4A4844;
 }
+
+.CodeRay span,
+.highlight span,
+.highlight code {
+  line-height: 1.5em;
+}

--- a/css/development/legend.css
+++ b/css/development/legend.css
@@ -207,3 +207,8 @@ p code.highlighter-rouge {
 .highlight code {
   line-height: 1.5em;
 }
+
+ul li,
+.toc li {
+  line-height: 1.5em;
+}


### PR DESCRIPTION
Something went haywire with #204, #205  and I needed to add these styles back in. 😕 