### PR TITLE
Update the FAQ section on sessions

### DIFF
--- a/faq.markdown
+++ b/faq.markdown
@@ -59,7 +59,11 @@ Sessions are disabled by default. You need to enable them and then use the
       session[:message]   # => 'Hello World!'
     end
 
-If you need to set additional parameters for sessions, like expiration date, use [`Rack::Session::Cookie`](http://www.rubydoc.info/github/rack/rack/Rack/Session/Cookie) directly instead of `enable :sessions` (example from _Rack_ documentation):
+See the [Sinatra README](http://www.sinatrarb.com/intro.html#Using%20Sessions)
+on how to set additional parameters for sessions, like the session secret
+or expiration date.
+
+You can also use [`Rack::Session::Cookie`](http://www.rubydoc.info/github/rack/rack/Rack/Session/Cookie) directly instead of `enable :sessions` (example from _Rack_ documentation):
 
     use Rack::Session::Cookie, :key => 'rack.session',
                                :domain => 'foo.com',


### PR DESCRIPTION
Clarify that `enable :sessions' can be used with additional parameters and refer to the Sinatra README for more information.

I recently went to the FAQ first, and got the impression that I had to use Rack::Session::Cookie when I want to set some parameters, like expiration date, which is wrong.