### PR TITLE
Change RACK_ENV references to APP_ENV

### DIFF
--- a/configuration.markdown
+++ b/configuration.markdown
@@ -82,8 +82,8 @@ Built-in Settings
 
 A symbol specifying the deployment environment; typically set to one of
 `:development`, `:test`, or `:production`. The `:environment` defaults to
-the value of the `RACK_ENV` environment variable (`ENV['RACK_ENV']`), or
-`:development` when no `RACK_ENV` environment variable is set.
+the value of the `APP_ENV` environment variable (`ENV['APP_ENV']`), or
+`:development` when no `APP_ENV` environment variable is set.
 
 The environment can be set explicitly:
 

--- a/faq.markdown
+++ b/faq.markdown
@@ -349,7 +349,7 @@ Assuming you have this simple implementation of HTTP authentication in your `app
 
 You can test it like this with [_Rack::Test_](https://github.com/brynary/rack-test):
 
-    ENV['RACK_ENV'] = 'test'
+    ENV['APP_ENV'] = 'test'
     require 'test/unit'
     require 'rack/test'
 

--- a/testing.markdown
+++ b/testing.markdown
@@ -47,7 +47,7 @@ makes a few helper methods and attributes available.
 The following is a simple example that ensures the hello world app functions
 properly:
 
-    ENV['RACK_ENV'] = 'test'
+    ENV['APP_ENV'] = 'test'
 
     require 'hello_world'
     require 'test/unit'
@@ -78,7 +78,7 @@ For a variety of reasons you may not want to include `Rack::Test::Methods`
 into your own classes. `Rack::Test` supports this style of testing as well,
 here is the above example without using Mixin.
 
-    ENV['RACK_ENV'] = 'test'
+    ENV['APP_ENV'] = 'test'
 
     require 'hello_world'
     require 'test/unit'
@@ -191,7 +191,7 @@ removed in Sinatra `1.0`.
 Sinatra can be tested under plain RSpec. The `Rack::Test` module should be
 included within the `describe` block:
 
-    ENV['RACK_ENV'] = 'test'
+    ENV['APP_ENV'] = 'test'
 
     require 'hello_world'  # <-- your sinatra app
     require 'rspec'
@@ -225,7 +225,7 @@ Make `Rack::Test` available to all spec contexts by including it via
 
 Testing with Bacon is similar to `test/unit` and RSpec:
 
-    ENV['RACK_ENV'] = 'test'
+    ENV['APP_ENV'] = 'test'
 
     require 'hello_world'  # <-- your sinatra app
     require 'bacon'
@@ -257,7 +257,7 @@ Make `Rack::Test` available to all spec contexts by including it in
 The `Rack::Test` module should be included within the context of the
 `describe` block:
 
-    ENV['RACK_ENV'] = 'test'
+    ENV['APP_ENV'] = 'test'
 
     require 'hello_world'  # <-- your sinatra app
     require 'test/spec'
@@ -289,7 +289,7 @@ Make `Rack::Test` available to all spec contexts by including it in
 
 From `Webrat`'s wiki where you'll find more [examples][].
 
-    ENV['RACK_ENV'] = 'test'
+    ENV['APP_ENV'] = 'test'
 
     require 'hello_world'  # <-- your sinatra app
     require 'rack/test'
@@ -319,7 +319,7 @@ From `Webrat`'s wiki where you'll find more [examples][].
 `Capybara` will use `Rack::Test` by default. You can use another driver, like
 `Selenium`, by setting the default_driver.
 
-    ENV['RACK_ENV'] = 'test'
+    ENV['APP_ENV'] = 'test'
 
     require 'hello_world'  # <-- your sinatra app
     require 'capybara'


### PR DESCRIPTION
After pull request [#984 (Introduce APP_ENV and remove RACK_ENV)](https://github.com/sinatra/sinatra/pull/984), Sinatra switched from using the `RACK_ENV` environment variable to `APP_ENV`, for specifying the application environment.

The references to `RACK_ENV`were never updated on the website to reflect this change, so this pull request fixes that.