### PR TITLE
Update documentation to make `set` behavior a bit clearer

### DIFF
--- a/configuration.markdown
+++ b/configuration.markdown
@@ -31,8 +31,8 @@ end
 
 ### Deferring evaluation
 
-When the setting value is a `Proc`, evaluation is performed when the setting
-is read so that other settings may be used to calculate the value:
+When the setting value is a `Proc`, evaluation is performed every time the
+setting is read so that other settings may be used to calculate the value:
 
 {% highlight ruby %}
 set :foo, 'bar'


### PR DESCRIPTION
This was unclear and tripped us up at work -- we thought `set` functioned as a memoized deferred-evaluation proc, but that assumption was very, very wrong. This PR updates the documentation to indicate that `set` with a `Proc` actually evaluates every time the setting is retrieved, as per https://github.com/sinatra/sinatra/blob/a4dd24add24f2dd0e7299b9e68e12038138294d3/lib/sinatra/base.rb#L1221-L1223 

