### PR TITLE
Mention Erubi in auto_escape_html FAQ

### DIFF
--- a/faq.markdown
+++ b/faq.markdown
@@ -245,9 +245,9 @@ for the tip!
 How do I automatically escape HTML? {#auto_escape_html}
 ---------------------
 
-Require [Erubis](https://rubygems.org/gems/erubis) and set `escape_html` to `true`:
+Require [Erubis](https://rubygems.org/gems/erubis) or [Erubi](https://rubygems.org/gems/erubi) and set `escape_html` to `true`:
 
-    require 'erubis'
+    require 'erubis' # or 'erubi'
     set :erb, :escape_html => true
 
 Then, any templates rendered with Erubis will be automatically escaped:


### PR DESCRIPTION
The FAQ only mentions Erubis in auto_escape_html document.
But escape_html options is available also in Erubi (https://github.com/jeremyevans/erubi).
So this pull request will adds Erubi to the FAQ.



We can confirm that Erubi supports escape_html with the following code.

```ruby
# Save this code as config.ru

require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'
  gem 'sinatra'
  gem 'erubi'
end

set :erb, escape_html: true

get '/' do
  @xss = '<script>alert("Hello!")</script>'
  erb <<~ERB
    <%= @xss %>
  ERB
end

run Sinatra::Application
```

```bash
$ rackup
$ curl localhost:9292
&lt;script&gt;alert(&quot;Hello!&quot;)&lt;/script&gt;
```