### PR TITLE
* faq.markdown: Add a little extra information about escaping for XSS…

### DIFF
--- a/faq.markdown
+++ b/faq.markdown
@@ -233,11 +233,23 @@ in your helpers as follows:
       def h(text)
         Rack::Utils.escape_html(text)
       end
+
+      def hattr(text)
+        Rack::Utils.escape_path(text)
+      end
     end
 
-Now you can escape HTML in your templates like this:
+Now you can escape HTML entities inside outputted text in your templates in one of two ways:
 
-    <%= h scary_output %>
+    <div><%= h scary_output %></div>
+
+or using the `<%==` feature:
+
+    <div><%== scary_output %></div>
+
+And you can escape text inside element attributes in your templates like this:
+
+    <a href="<%= hattr scary_output %>" >A nice safe link!</a>
 
 Thanks to [Chris Schneider](http://www.gittr.com/index.php/archive/using-rackutils-in-sinatra-escape_html-h-in-rails/)
 for the tip!


### PR DESCRIPTION
… protection

Hello!

To best protect against XSS it was recommended in [1] to escape output in different ways depending on the HTML context (whether it's a tag body or an attribute). I added a bit of extra information to the FAQ about how to do this and also added information about the <%== escaping method which is nice and quick to use.

Hope this change is useful!

Reference [1]: https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html