### PR TITLE
Remove the broken links to language-specific READMEs

### DIFF
--- a/intro.html
+++ b/intro.html
@@ -3,18 +3,6 @@ title: "Sinatra: README"
 layout: default
 ---
 
-<p><small>This page is also available in
-  <a href="/intro-zh.html">Chinese</a>,
-  <a href="/intro-fr.html">French</a>,
-  <a href="/intro-de.html">German</a>,
-  <a href="/intro-hu.html">Hungarian</a>,
-  <a href="/intro-ko.html">Korean</a>,
-  <a href="/intro-pt-br.html">Portuguese (Brazilian)</a>,
-  <a href="/intro-pt-pt.html">Portuguese (European)</a>,
-  <a href="/intro-ru.html">Russian</a>,
-  <a href="/intro-es.html">Spanish</a> and
-  <a href="/intro-ja.html">Japanese</a>.</small></p>
-
 <h1>Getting Started</h1>
 
 {% include README.html %}


### PR DESCRIPTION
which are no longer maintained by sinatra/sinatra#1807 and removed by #295. This pull request closes #297.


| before | after |
| - | - |
| ![127 0 0 1_4000_sinatra github com_intro html (1)](https://user-images.githubusercontent.com/7645585/198395466-264306c1-bd47-4187-b68e-ecb1b85899cf.png) | ![127 0 0 1_4000_sinatra github com_intro html](https://user-images.githubusercontent.com/7645585/198395480-6023e292-c75d-47d1-b272-ce548d335160.png) |

