### PR TITLE
Docs: Format HTML in rack-protection README

### DIFF
--- a/_includes/rack-protection-readme.html
+++ b/_includes/rack-protection-readme.html
@@ -84,8 +84,11 @@
 
 <h2>Cookie Tossing</h2>
 
-<p>Prevented by:
-* <a href="http://www.sinatrarb.com/protection/cookie_tossing"><code>Rack::Protection::CookieTossing</code></a> (not included by <code>use Rack::Protection</code>)</p>
+<p>Prevented by:</p>
+
+<ul>
+  <li><a href="http://www.sinatrarb.com/protection/cookie_tossing"><code>Rack::Protection::CookieTossing</code></a> (not included by <code>use Rack::Protection</code>)</li>
+</ul>
 
 <h2>IP Spoofing</h2>
 
@@ -112,9 +115,9 @@
 <h1>Instrumentation</h1>
 
 <p>Instrumentation is enabled by passing in an instrumenter as an option.
-~~~~
-use Rack::Protection, instrumenter: ActiveSupport::Notifications
-~~~~</p>
 
-<p>The instrumenter is passed a namespace (String) and environment (Hash). The namespace is ‘rack.protection’ and the attack type can be obtained from the environment key ‘rack.protection.attack’.</p>
+<pre><code> use Rack::Protection, instrumenter: ActiveSupport::Notifications
+</code></pre>
+
+<p>The instrumenter is passed a namespace (String) and environment (Hash). The namespace is <code>rack.protection</code> and the attack type can be obtained from the environment key <code>rack.protection.attack</code>.</p>
 


### PR DESCRIPTION
This repairs a few uglinesses in the rack-protection README.

# Before:

<img width="925" alt="bild" src="https://user-images.githubusercontent.com/211/209114785-a524f2e3-347a-4df3-92fb-093931f0f3f3.png">

<img width="804" alt="bild" src="https://user-images.githubusercontent.com/211/209114679-4fd65794-a7d9-44af-b780-f50c8def54d5.png">


# After:

<img width="784" alt="bild" src="https://user-images.githubusercontent.com/211/209114818-f444ce85-71dc-42fb-ba44-47cfd0a0e976.png">

<img width="788" alt="bild" src="https://user-images.githubusercontent.com/211/209114725-a36a9a1c-ea1a-4516-8e02-b69ce915dfa7.png">

