### PR TITLE
Fix Ruby 3.2 compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,7 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    liquid (4.0.3)
+    liquid (4.0.4)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)


### PR DESCRIPTION
This upgrades liquid from 4.0.3 to 4.0.4 which includes the actual Ruby 3.2 compatibility changes:

- https://github.com/Shopify/liquid/blob/4-0-stable/History.md
- https://github.com/Shopify/liquid/compare/v4.0.3...v4.0.4