### PR TITLE
Switch Slack navbar link with Discord replacement

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -11,7 +11,7 @@
     <li class='nav-list-item'><a href='http://github.com/sinatra/sinatra/contributors'>CREW</a></li>
     <li class='nav-list-item'><a href='{{ site.baseurl }}/contributing.html'>CONTRIBUTE</a></li>
     <li class='nav-list-item'><a href='{{ site.baseurl }}/about.html'>ABOUT</a></li>
-    <li class='nav-list-item'><a href='http://sinatra-slack.herokuapp.com'>SLACK</a></li>
+    <li class='nav-list-item'><a href='https://discord.gg/ncjsfsNHh7'>DISCORD</a></li>
     <li class='nav-list-item' id='toggle-nav-logo'>
       <a href='#'><img src="{{ site.baseurl }}/images/logo.png" height='59' width='86' alt="Sinatra Logo"></a>
     </li>
@@ -27,7 +27,7 @@
       <li class='hidden-nav-list-item'><a href='http://github.com/sinatra/sinatra/contributors'>CREW</a></li>
       <li class='hidden-nav-list-item'><a href='{{ site.baseurl }}/about.html'>ABOUT</a></li>
       <li class='hidden-nav-list-item'><a href='{{ site.baseurl }}/contributing.html'>CONTRIBUTE</a></li>
-      <li class='hidden-nav-list-item'><a href='http://sinatra-slack.herokuapp.com'>SLACK</a></li>
+      <li class='hidden-nav-list-item'><a href='https://discord.gg/ncjsfsNHh7'>DISCORD</a></li>
     </ul>
   </div>
 


### PR DESCRIPTION
Following https://github.com/sinatra/sinatra/pull/1861. Other outdated links to Slack are updated in #303.