### PR TITLE
Better `Rack::Utils` escape HTML link

### DIFF
--- a/faq.markdown
+++ b/faq.markdown
@@ -220,7 +220,7 @@ And in `mailerapp.rb`:
 How do I escape HTML? {#escape_html}
 ---------------------
 
-Use [Rack::Utils](http://www.rubydoc.info/github/rack/rack/Rack/Utils)
+Use [Rack::Utils](https://www.rubydoc.info/gems/rack/Rack/Utils#escape_html-class_method)
 in your helpers as follows:
 
     helpers do


### PR DESCRIPTION
The previous one supplied zero documentation of the `escape_html` method.