### PR TITLE
(Issue 323) : Fix link to #views-templates in the README.md; it had an extra "-". 

### DIFF
--- a/_includes/README.html
+++ b/_includes/README.html
@@ -327,7 +327,7 @@ a different location by setting the <code>:public_folder</code> option:</p>
 <p>Use the <code>:static_cache_control</code> setting (see <a href="#cache-control">below</a>) to add
 <code>Cache-Control</code> header info.</p>
 
-<h2 id="views--templates">Views / Templates</h2>
+<h2 id="views-templates">Views / Templates</h2>
 
 <p>Each template language is exposed via its own rendering method. These
 methods simply return a string:</p>


### PR DESCRIPTION
https://github.com/sinatra/sinatra.github.com/issues/323

A very minor change. The link to `#views-templates` has an extra dash in it; this fixes it.

Thank you to all for your work on the web and on Sinatra!

# 👋  